### PR TITLE
[Feature] Vertex AI Gemini 공통 래퍼 구현 (#3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pydantic>=2.0
 pydantic-settings>=2.0
 pytest>=7.0
+google-genai>=1.0

--- a/shared/llm/gemini_client.py
+++ b/shared/llm/gemini_client.py
@@ -130,6 +130,15 @@ class GeminiClient:
         except Exception as exc:
             raise LLMError(str(exc)) from exc
 
+        usage = response.usage_metadata
+        if usage is not None:
+            print(
+                f"[Gemini] tokens  in={usage.prompt_token_count or 0}"
+                f"  out={usage.candidates_token_count or 0}"
+                f"  total={usage.total_token_count or 0}"
+                f"  (model={model or self._default_model})"
+            )
+
         return response.parsed if response_schema is not None else response.text
 
 

--- a/shared/llm/gemini_client.py
+++ b/shared/llm/gemini_client.py
@@ -1,0 +1,136 @@
+"""Vertex AI Gemini 공통 래퍼.
+
+사용 예
+-------
+텍스트 입력:
+    >>> from shared.llm.gemini_client import gemini_client
+    >>> answer = gemini_client.generate("안녕하세요!")
+
+멀티모달 입력 — 로컬 파일:
+    >>> from pathlib import Path
+    >>> part = GeminiClient.part_from_path(Path("contract.pdf"), mime_type="application/pdf")
+    >>> answer = gemini_client.generate(["이 계약서를 요약해.", part])
+
+멀티모달 입력 — GCS 파일:
+    >>> from google.genai import types
+    >>> part = types.Part.from_uri(file_uri="gs://bucket/contract.pdf", mime_type="application/pdf")
+    >>> answer = gemini_client.generate(["이 계약서를 요약해.", part])
+
+구조화 출력 (Pydantic 스키마):
+    >>> from pydantic import BaseModel
+    >>> class Summary(BaseModel):
+    ...     title: str
+    ...     points: list[str]
+    >>> result = gemini_client.generate("요약해줘.", response_schema=Summary)
+    >>> isinstance(result, Summary)
+    True
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from google import genai
+
+from shared.config import settings
+
+
+class LLMError(RuntimeError):
+    """Gemini API 호출 중 발생한 모든 오류의 단일 타입."""
+
+
+class GeminiClient:
+    """Vertex AI Gemini API 호출 래퍼.
+
+    vertexai=True 고정. ADC(Application Default Credentials)로 인증한다.
+    """
+
+    def __init__(
+        self,
+        *,
+        project: str | None = None,
+        location: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        self._project = project or settings.gcp_project_id
+        self._location = location or settings.gcp_location
+        self._default_model = model or settings.gemini_model
+        self._client = genai.Client(
+            vertexai=True,
+            project=self._project,
+            location=self._location,
+        )
+
+    @staticmethod
+    def part_from_path(path: str | Path, mime_type: str) -> Any:
+        """로컬 파일을 읽어 ``types.Part``로 변환한다.
+
+        Parameters
+        ----------
+        path:
+            로컬 파일 경로 (``str`` 또는 ``pathlib.Path``).
+        mime_type:
+            파일 MIME 타입. 예: ``"application/pdf"``, ``"image/jpeg"``,
+            ``"text/csv"``.
+        """
+        from google.genai import types
+
+        return types.Part.from_bytes(
+            data=Path(path).read_bytes(),
+            mime_type=mime_type,
+        )
+
+    def generate(
+        self,
+        contents: str | list,
+        *,
+        model: str | None = None,
+        system_instruction: str | None = None,
+        response_schema: type | None = None,
+    ) -> Any:
+        """텍스트 또는 파일을 입력받아 생성 결과를 반환한다.
+
+        Parameters
+        ----------
+        contents:
+            프롬프트 문자열, 또는 문자열과 ``types.Part``를 혼합한 리스트.
+            로컬 파일은 :meth:`part_from_path` 로, GCS 파일은
+            ``types.Part.from_uri()`` 로 변환하여 전달한다.
+        model:
+            사용할 모델 ID. None이면 생성자의 기본 모델 사용.
+        system_instruction:
+            시스템 프롬프트. None이면 전달하지 않음.
+        response_schema:
+            Pydantic ``BaseModel`` 서브클래스. 전달 시 구조화 JSON 출력을
+            요청하고 ``response.parsed`` (Pydantic 인스턴스)를 반환한다.
+            None이면 ``response.text`` (str)를 반환한다.
+
+        Raises
+        ------
+        LLMError
+            API 호출 중 예외 발생 시.
+        """
+        from google.genai import types
+
+        config_kwargs: dict[str, Any] = {}
+        if system_instruction is not None:
+            config_kwargs["system_instruction"] = system_instruction
+        if response_schema is not None:
+            config_kwargs["response_mime_type"] = "application/json"
+            config_kwargs["response_schema"] = response_schema
+
+        config = types.GenerateContentConfig(**config_kwargs) if config_kwargs else None
+
+        try:
+            response = self._client.models.generate_content(
+                model=model or self._default_model,
+                contents=contents,
+                config=config,
+            )
+        except Exception as exc:
+            raise LLMError(str(exc)) from exc
+
+        return response.parsed if response_schema is not None else response.text
+
+
+gemini_client: GeminiClient = GeminiClient()

--- a/tests/shared/test_gemini_client.py
+++ b/tests/shared/test_gemini_client.py
@@ -1,0 +1,232 @@
+"""shared.llm.gemini_client 단위 테스트."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shared.llm.gemini_client import GeminiClient, LLMError, gemini_client
+
+
+def _make_client() -> GeminiClient:
+    """genai.Client 생성을 mock한 GeminiClient 인스턴스를 반환한다."""
+    with patch("shared.llm.gemini_client.genai.Client"):
+        client = GeminiClient()
+    client._client = MagicMock()
+    return client
+
+
+def test_llm_error_is_runtime_error_subclass() -> None:
+    assert issubclass(LLMError, RuntimeError)
+
+
+def test_gemini_client_module_singleton_exists() -> None:
+    assert isinstance(gemini_client, GeminiClient)
+
+
+def test_generate_returns_response_text() -> None:
+    """generate()가 response.text를 반환한다."""
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.text = "생성된 답변"
+    client._client.models.generate_content.return_value = mock_response
+
+    assert client.generate("질문입니다") == "생성된 답변"
+
+
+def test_generate_uses_default_model() -> None:
+    """model 인자를 생략하면 생성자의 기본 모델을 사용한다."""
+    client = _make_client()
+    client._default_model = "gemini-2.5-flash"
+    mock_response = MagicMock()
+    mock_response.text = "응답"
+    client._client.models.generate_content.return_value = mock_response
+
+    client.generate("질문")
+
+    call_kwargs = client._client.models.generate_content.call_args.kwargs
+    assert call_kwargs["model"] == "gemini-2.5-flash"
+
+
+def test_generate_uses_overridden_model() -> None:
+    """model 인자를 명시하면 기본 모델 대신 해당 모델을 사용한다."""
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.text = "응답"
+    client._client.models.generate_content.return_value = mock_response
+
+    client.generate("질문", model="gemini-2.5-pro")
+
+    call_kwargs = client._client.models.generate_content.call_args.kwargs
+    assert call_kwargs["model"] == "gemini-2.5-pro"
+
+
+def test_generate_passes_contents() -> None:
+    """generate()가 contents를 그대로 API에 전달한다."""
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.text = "응답"
+    client._client.models.generate_content.return_value = mock_response
+
+    client.generate("테스트 프롬프트")
+
+    call_kwargs = client._client.models.generate_content.call_args.kwargs
+    assert call_kwargs["contents"] == "테스트 프롬프트"
+
+
+def test_generate_wraps_api_exception_as_llm_error() -> None:
+    """API 호출 중 예외 발생 시 LLMError로 래핑한다."""
+    client = _make_client()
+    client._client.models.generate_content.side_effect = RuntimeError("API 오류")
+
+    with pytest.raises(LLMError) as exc_info:
+        client.generate("질문")
+
+    assert "API 오류" in str(exc_info.value)
+
+
+def test_generate_llm_error_has_cause() -> None:
+    """LLMError는 원본 예외를 __cause__로 보존한다."""
+    client = _make_client()
+    original = RuntimeError("원본 오류")
+    client._client.models.generate_content.side_effect = original
+
+    with pytest.raises(LLMError) as exc_info:
+        client.generate("질문")
+
+    assert exc_info.value.__cause__ is original
+
+
+def test_generate_passes_system_instruction() -> None:
+    """system_instruction이 주어지면 GenerateContentConfig에 담아 전달한다."""
+    from google.genai import types
+
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.text = "응답"
+    client._client.models.generate_content.return_value = mock_response
+
+    client.generate("질문", system_instruction="당신은 법률 전문가입니다.")
+
+    call_kwargs = client._client.models.generate_content.call_args.kwargs
+    config = call_kwargs["config"]
+    assert isinstance(config, types.GenerateContentConfig)
+    assert config.system_instruction == "당신은 법률 전문가입니다."
+
+
+def test_generate_no_config_when_no_options() -> None:
+    """system_instruction과 response_schema 모두 생략 시 config=None으로 호출한다."""
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.text = "응답"
+    client._client.models.generate_content.return_value = mock_response
+
+    client.generate("질문")
+
+    call_kwargs = client._client.models.generate_content.call_args.kwargs
+    assert call_kwargs["config"] is None
+
+
+def test_generate_returns_parsed_when_response_schema_given() -> None:
+    """response_schema 전달 시 response.parsed를 반환한다."""
+    from pydantic import BaseModel
+
+    class Summary(BaseModel):
+        title: str
+        points: list[str]
+
+    client = _make_client()
+    expected = Summary(title="계약서 요약", points=["항목1", "항목2"])
+    mock_response = MagicMock()
+    mock_response.parsed = expected
+    client._client.models.generate_content.return_value = mock_response
+
+    result = client.generate("요약해줘.", response_schema=Summary)
+
+    assert result is expected
+
+
+def test_generate_sets_json_mime_type_when_response_schema_given() -> None:
+    """response_schema 전달 시 GenerateContentConfig에 response_mime_type='application/json'이 설정된다."""
+    from google.genai import types
+    from pydantic import BaseModel
+
+    class Tag(BaseModel):
+        label: str
+
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.parsed = Tag(label="계약")
+    client._client.models.generate_content.return_value = mock_response
+
+    client.generate("분류해줘.", response_schema=Tag)
+
+    call_kwargs = client._client.models.generate_content.call_args.kwargs
+    config = call_kwargs["config"]
+    assert isinstance(config, types.GenerateContentConfig)
+    assert config.response_mime_type == "application/json"
+    assert config.response_schema is Tag
+
+
+def test_generate_returns_text_when_no_response_schema() -> None:
+    """response_schema 미전달 시 response.text를 반환한다."""
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.text = "텍스트 응답"
+    client._client.models.generate_content.return_value = mock_response
+
+    result = client.generate("질문")
+
+    assert result == "텍스트 응답"
+
+
+def test_generate_accepts_multimodal_contents_gcs() -> None:
+    """contents에 GCS URI Part를 혼합한 리스트를 전달할 수 있다."""
+    from google.genai import types
+
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.text = "분석 결과"
+    client._client.models.generate_content.return_value = mock_response
+
+    part = types.Part.from_uri(
+        file_uri="gs://test-bucket/contract.pdf", mime_type="application/pdf"
+    )
+    contents = ["이 계약서를 요약해.", part]
+
+    result = client.generate(contents)
+
+    call_kwargs = client._client.models.generate_content.call_args.kwargs
+    assert call_kwargs["contents"] is contents
+    assert result == "분석 결과"
+
+
+def test_part_from_path_reads_local_file(tmp_path) -> None:
+    """part_from_path()가 로컬 파일을 읽어 types.Part를 반환한다."""
+    from google.genai import types
+
+    local_file = tmp_path / "sample.pdf"
+    local_file.write_bytes(b"%PDF-sample")
+
+    part = GeminiClient.part_from_path(local_file, mime_type="application/pdf")
+
+    assert isinstance(part, types.Part)
+
+
+def test_generate_accepts_local_file_part(tmp_path) -> None:
+    """part_from_path()로 만든 Part를 generate()에 전달할 수 있다."""
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.text = "요약 결과"
+    client._client.models.generate_content.return_value = mock_response
+
+    local_file = tmp_path / "contract.pdf"
+    local_file.write_bytes(b"%PDF-sample")
+    part = GeminiClient.part_from_path(local_file, mime_type="application/pdf")
+    contents = ["요약해줘.", part]
+
+    result = client.generate(contents)
+
+    call_kwargs = client._client.models.generate_content.call_args.kwargs
+    assert call_kwargs["contents"] is contents
+    assert result == "요약 결과"


### PR DESCRIPTION
## 📝 변경 사항
- `shared/llm/gemini_client.py`: `google.genai.Client(vertexai=True)` 기반 `GeminiClient` 클래스 구현
  - `generate()`: 텍스트·멀티모달 입력, Pydantic 구조화 출력(`response_schema`), `system_instruction` 지원
  - `part_from_path()`: 로컬 파일을 `types.Part`로 변환하는 정적 헬퍼
  - `LLMError`: 모든 API 오류를 래핑하는 커스텀 예외 (원본 `__cause__` 보존)
  - 매 호출 시 입력/출력/전체 토큰 사용량 stdout 출력
  - 모듈 레벨 싱글턴 `gemini_client` 노출
- `shared/llm/__init__.py`: 패키지 마커
- `requirements.txt`: `google-genai>=1.0` 의존성 추가
- `tests/shared/test_gemini_client.py`: 단위 테스트 16개
-

## 🔗 관련 이슈
closes #3 

## 📸 스크린샷 (선택)
해당 없음 (UI 변경 없음)

## 🧪 테스트
```bash
pytest tests/shared/test_gemini_client.py -v
```

- 뼈대: `LLMError` 상속 관계, 모듈 싱글턴 존재 확인
- 정상 경로: `response.text` 반환, 기본 모델 사용, 모델 오버라이드, contents 전달
- 오류 경로: API 예외 → `LLMError` 래핑, `__cause__` 보존
- config 전달: `system_instruction` 전달 시 `GenerateContentConfig` 생성, 생략 시 `config=None`
- 구조화 출력: `response_schema` 전달 시 `response.parsed` 반환, `response_mime_type="application/json"` 설정
- 멀티모달: GCS URI Part 전달, `part_from_path()` 로컬 파일 읽기, 로컬 Part를 `generate()`에 전달
- 

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
- `genai.Client(vertexai=True)` 초기화는 GCP 인증 없이도 객체 생성까지 성공하므로, 모듈 레벨 싱글턴이 테스트 환경에서도 정상 import됩니다.
- 테스트는 `_make_client()` 헬퍼로 `genai.Client`를 패치한 뒤 `_client` 속성을 `MagicMock`으로 교체하여 격리합니다.
- `Part.from_uri()`는 `file_uri=` 키워드 전용입니다 (positional 사용 시 `TypeError`).
- 토큰 사용량은 `print()`로 항상 출력됩니다. 추후 필요 시 `logging`으로 전환 가능합니다.