### PR TITLE
[Feature] Cloud SQL 연결 관리 및 범용 CRUD 유틸리티 구현 (#5)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pydantic>=2.0
 pydantic-settings>=2.0
 pytest>=7.0
 google-genai>=1.0
+cloud-sql-python-connector[pg8000]>=1.0
+sqlalchemy>=2.0

--- a/shared/db/connection.py
+++ b/shared/db/connection.py
@@ -1,0 +1,189 @@
+"""Cloud SQL 연결 관리 및 범용 CRUD 유틸리티.
+
+사용 예
+-------
+DDL:
+    >>> from shared.db.connection import get_db_client
+    >>> db = get_db_client()
+    >>> db.execute_ddl("CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, name TEXT)")
+
+INSERT:
+    >>> from sqlalchemy import text
+    >>> db = get_db_client()
+    >>> db.execute(text("INSERT INTO users (name) VALUES (:name)"), {"name": "홍길동"})
+
+SELECT:
+    >>> db = get_db_client()
+    >>> rows = db.fetch_all(text("SELECT * FROM users"))
+    >>> row = db.fetch_one(text("SELECT * FROM users WHERE id = :id"), {"id": 1})
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy
+from google.cloud.sql.connector import Connector
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from shared.config import settings
+
+
+class DBError(RuntimeError):
+    """DB 관련 모든 오류의 단일 타입."""
+
+
+class DBClient:
+    """Cloud SQL 연결 풀 관리 및 범용 CRUD 유틸리티.
+
+    Cloud SQL Python Connector로 비밀번호 기반 보안 연결을 수립하고,
+    SQLAlchemy Core Engine으로 커넥션 풀을 관리한다.
+    """
+
+    def __init__(
+        self,
+        *,
+        instance_connection_name: str | None = None,
+        db_user: str | None = None,
+        db_password: str | None = None,
+        db_name: str | None = None,
+    ) -> None:
+        self._instance = instance_connection_name or settings.cloud_sql_connection
+        self._db_user = db_user or settings.db_user
+        self._db_password = db_password or settings.db_password
+        self._db_name = db_name or settings.db_name
+        self._connector = Connector()
+        self._engine: Engine = self._create_engine()
+
+    def _getconn(self) -> Any:
+        """Cloud SQL Python Connector를 통해 pg8000 연결을 반환한다."""
+        return self._connector.connect(
+            self._instance,
+            "pg8000",
+            user=self._db_user,
+            password=self._db_password,
+            db=self._db_name,
+        )
+
+    def _create_engine(self) -> Engine:
+        """SQLAlchemy Engine을 생성한다."""
+        return sqlalchemy.create_engine(
+            "postgresql+pg8000://",
+            creator=self._getconn,
+            pool_size=5,
+            max_overflow=2,
+            pool_timeout=30,
+            pool_recycle=1800,
+        )
+
+    @property
+    def engine(self) -> Engine:
+        """SQLAlchemy Engine 인스턴스를 반환한다."""
+        return self._engine
+
+    def execute(
+        self, statement: Any, params: dict[str, Any] | None = None
+    ) -> None:
+        """INSERT, UPDATE, DELETE 등 변경 쿼리를 실행한다.
+
+        Parameters
+        ----------
+        statement:
+            SQLAlchemy ``text()`` 객체.
+        params:
+            바인드 파라미터 딕셔너리.
+
+        Raises
+        ------
+        DBError
+            쿼리 실행 중 예외 발생 시.
+        """
+        try:
+            with self._engine.begin() as conn:
+                conn.execute(statement, params or {})
+        except Exception as exc:
+            raise DBError(str(exc)) from exc
+
+    def fetch_one(
+        self, statement: Any, params: dict[str, Any] | None = None
+    ) -> dict[str, Any] | None:
+        """단일 행을 조회하여 딕셔너리로 반환한다. 결과 없으면 None.
+
+        Parameters
+        ----------
+        statement:
+            SQLAlchemy ``text()`` 객체.
+        params:
+            바인드 파라미터 딕셔너리.
+
+        Raises
+        ------
+        DBError
+            쿼리 실행 중 예외 발생 시.
+        """
+        try:
+            with self._engine.connect() as conn:
+                result = conn.execute(statement, params or {})
+                row = result.mappings().first()
+                return dict(row) if row is not None else None
+        except Exception as exc:
+            raise DBError(str(exc)) from exc
+
+    def fetch_all(
+        self, statement: Any, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        """다중 행을 조회하여 딕셔너리 리스트로 반환한다.
+
+        Parameters
+        ----------
+        statement:
+            SQLAlchemy ``text()`` 객체.
+        params:
+            바인드 파라미터 딕셔너리.
+
+        Raises
+        ------
+        DBError
+            쿼리 실행 중 예외 발생 시.
+        """
+        try:
+            with self._engine.connect() as conn:
+                result = conn.execute(statement, params or {})
+                return [dict(row) for row in result.mappings().all()]
+        except Exception as exc:
+            raise DBError(str(exc)) from exc
+
+    def execute_ddl(self, statement: str) -> None:
+        """CREATE TABLE, DROP TABLE 등 DDL을 실행한다.
+
+        Parameters
+        ----------
+        statement:
+            DDL SQL 문자열.
+
+        Raises
+        ------
+        DBError
+            DDL 실행 중 예외 발생 시.
+        """
+        try:
+            with self._engine.begin() as conn:
+                conn.execute(text(statement))
+        except Exception as exc:
+            raise DBError(str(exc)) from exc
+
+    def close(self) -> None:
+        """엔진과 커넥터를 정리한다."""
+        self._engine.dispose()
+        self._connector.close()
+
+
+_db_client: DBClient | None = None
+
+
+def get_db_client() -> DBClient:
+    """DBClient 싱글턴을 반환한다. 최초 호출 시 1회만 생성."""
+    global _db_client  # noqa: PLW0603
+    if _db_client is None:
+        _db_client = DBClient()
+    return _db_client

--- a/tests/shared/test_db_connection.py
+++ b/tests/shared/test_db_connection.py
@@ -1,0 +1,238 @@
+"""shared.db.connection 단위 테스트."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import text
+
+from shared.db.connection import DBClient, DBError, get_db_client
+
+
+def _make_client() -> DBClient:
+    """Connector와 Engine 생성을 mock한 DBClient 인스턴스를 반환한다."""
+    with patch("shared.db.connection.Connector"), \
+         patch("shared.db.connection.sqlalchemy.create_engine") as mock_engine:
+        mock_engine.return_value = MagicMock()
+        client = DBClient()
+    return client
+
+
+# --- DBError ---
+
+def test_db_error_is_runtime_error_subclass() -> None:
+    assert issubclass(DBError, RuntimeError)
+
+
+# --- get_db_client (lazy factory) ---
+
+def test_get_db_client_returns_db_client_instance() -> None:
+    """get_db_client()가 DBClient 인스턴스를 반환한다."""
+    import shared.db.connection as mod
+    with patch("shared.db.connection.Connector"), \
+         patch("shared.db.connection.sqlalchemy.create_engine") as mock_engine:
+        mock_engine.return_value = MagicMock()
+        mod._db_client = None  # 리셋하여 lazy 생성 검증
+        client = get_db_client()
+        assert isinstance(client, DBClient)
+        mod._db_client = None  # 테스트 후 정리
+
+
+def test_get_db_client_returns_same_instance() -> None:
+    """get_db_client()가 동일 인스턴스를 반환한다 (싱글턴)."""
+    import shared.db.connection as mod
+    with patch("shared.db.connection.Connector"), \
+         patch("shared.db.connection.sqlalchemy.create_engine") as mock_engine:
+        mock_engine.return_value = MagicMock()
+        mod._db_client = None
+        first = get_db_client()
+        second = get_db_client()
+        assert first is second
+        mod._db_client = None
+
+
+# --- execute ---
+
+def test_execute_calls_engine_begin() -> None:
+    """execute()가 engine.begin() 컨텍스트 내에서 쿼리를 실행한다."""
+    client = _make_client()
+    mock_conn = MagicMock()
+    client._engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    client._engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    stmt = text("INSERT INTO users (name) VALUES (:name)")
+    client.execute(stmt, {"name": "홍길동"})
+
+    mock_conn.execute.assert_called_once_with(stmt, {"name": "홍길동"})
+
+
+def test_execute_wraps_exception_as_db_error() -> None:
+    """execute() 중 예외 발생 시 DBError로 래핑한다."""
+    client = _make_client()
+    client._engine.begin.side_effect = RuntimeError("DB 오류")
+
+    with pytest.raises(DBError) as exc_info:
+        client.execute(text("INSERT INTO t VALUES (1)"))
+
+    assert "DB 오류" in str(exc_info.value)
+
+
+def test_execute_db_error_has_cause() -> None:
+    """DBError는 원본 예외를 __cause__로 보존한다."""
+    client = _make_client()
+    original = RuntimeError("원본 오류")
+    client._engine.begin.side_effect = original
+
+    with pytest.raises(DBError) as exc_info:
+        client.execute(text("DELETE FROM t"))
+
+    assert exc_info.value.__cause__ is original
+
+
+# --- fetch_one ---
+
+def test_fetch_one_returns_dict() -> None:
+    """fetch_one()이 결과를 딕셔너리로 반환한다."""
+    client = _make_client()
+    mock_conn = MagicMock()
+    mock_result = MagicMock()
+    mock_row = {"id": 1, "name": "홍길동"}
+    mock_result.mappings.return_value.first.return_value = mock_row
+    mock_conn.execute.return_value = mock_result
+    client._engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    client._engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    result = client.fetch_one(text("SELECT * FROM users WHERE id = :id"), {"id": 1})
+
+    assert result == {"id": 1, "name": "홍길동"}
+
+
+def test_fetch_one_returns_none_when_no_result() -> None:
+    """fetch_one()이 결과 없으면 None을 반환한다."""
+    client = _make_client()
+    mock_conn = MagicMock()
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.first.return_value = None
+    mock_conn.execute.return_value = mock_result
+    client._engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    client._engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    result = client.fetch_one(text("SELECT * FROM users WHERE id = :id"), {"id": 999})
+
+    assert result is None
+
+
+def test_fetch_one_wraps_exception_as_db_error() -> None:
+    """fetch_one() 중 예외 발생 시 DBError로 래핑한다."""
+    client = _make_client()
+    client._engine.connect.side_effect = RuntimeError("연결 실패")
+
+    with pytest.raises(DBError):
+        client.fetch_one(text("SELECT 1"))
+
+
+# --- fetch_all ---
+
+def test_fetch_all_returns_list_of_dicts() -> None:
+    """fetch_all()이 딕셔너리 리스트를 반환한다."""
+    client = _make_client()
+    mock_conn = MagicMock()
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.all.return_value = [
+        {"id": 1, "name": "홍길동"},
+        {"id": 2, "name": "김철수"},
+    ]
+    mock_conn.execute.return_value = mock_result
+    client._engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    client._engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    result = client.fetch_all(text("SELECT * FROM users"))
+
+    assert len(result) == 2
+    assert result[0] == {"id": 1, "name": "홍길동"}
+    assert result[1] == {"id": 2, "name": "김철수"}
+
+
+def test_fetch_all_returns_empty_list_when_no_results() -> None:
+    """fetch_all()이 결과 없으면 빈 리스트를 반환한다."""
+    client = _make_client()
+    mock_conn = MagicMock()
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.all.return_value = []
+    mock_conn.execute.return_value = mock_result
+    client._engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    client._engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    result = client.fetch_all(text("SELECT * FROM users WHERE 1=0"))
+
+    assert result == []
+
+
+def test_fetch_all_wraps_exception_as_db_error() -> None:
+    """fetch_all() 중 예외 발생 시 DBError로 래핑한다."""
+    client = _make_client()
+    client._engine.connect.side_effect = RuntimeError("타임아웃")
+
+    with pytest.raises(DBError):
+        client.fetch_all(text("SELECT * FROM users"))
+
+
+# --- execute_ddl ---
+
+def test_execute_ddl_calls_engine_begin() -> None:
+    """execute_ddl()이 engine.begin() 컨텍스트 내에서 DDL을 실행한다."""
+    client = _make_client()
+    mock_conn = MagicMock()
+    client._engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    client._engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    client.execute_ddl("CREATE TABLE test (id SERIAL PRIMARY KEY)")
+
+    mock_conn.execute.assert_called_once()
+
+
+def test_execute_ddl_wraps_exception_as_db_error() -> None:
+    """execute_ddl() 중 예외 발생 시 DBError로 래핑한다."""
+    client = _make_client()
+    client._engine.begin.side_effect = RuntimeError("권한 없음")
+
+    with pytest.raises(DBError) as exc_info:
+        client.execute_ddl("DROP TABLE important")
+
+    assert "권한 없음" in str(exc_info.value)
+
+
+# --- execute with default params ---
+
+def test_execute_uses_empty_dict_when_no_params() -> None:
+    """params 미전달 시 빈 딕셔너리로 실행한다."""
+    client = _make_client()
+    mock_conn = MagicMock()
+    client._engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    client._engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    stmt = text("DELETE FROM logs")
+    client.execute(stmt)
+
+    mock_conn.execute.assert_called_once_with(stmt, {})
+
+
+# --- close ---
+
+def test_close_disposes_engine_and_connector() -> None:
+    """close()가 engine.dispose()와 connector.close()를 호출한다."""
+    client = _make_client()
+
+    client.close()
+
+    client._engine.dispose.assert_called_once()
+    client._connector.close.assert_called_once()
+
+
+# --- engine property ---
+
+def test_engine_property_returns_engine() -> None:
+    """engine 프로퍼티가 SQLAlchemy Engine을 반환한다."""
+    client = _make_client()
+
+    assert client.engine is client._engine


### PR DESCRIPTION
## 📝 변경 사항
- Cloud SQL Python Connector + SQLAlchemy Core 기반 DB 연결 풀 관리 클래스(`DBClient`) 구현
- 범용 CRUD 유틸리티 메서드 제공: `execute()`, `fetch_one()`, `fetch_all()`, `execute_ddl()`
- 모든 DB 오류를 `DBError(RuntimeError)` 단일 타입으로 래핑
- `get_db_client()` lazy factory로 싱글턴 인스턴스 제공 (import 시점 부작용 없음)
- `requirements.txt`에 `cloud-sql-python-connector[pg8000]`, `sqlalchemy` 의존성 추가
-

## 🔗 관련 이슈
closes #5

## 📸 스크린샷 (선택)
해당 없음 (백엔드 모듈)

## 🧪 테스트
- mock 기반 단위 테스트 17건 작성 (`tests/shared/test_db_connection.py`)
  - DBClient 생성, execute, fetch_one, fetch_all, execute_ddl, close, engine property
  - 예외 발생 시 DBError 래핑 및 원본 예외 체이닝 검증
  - get_db_client() lazy factory 동작 검증
- 실제 Cloud SQL 인스턴스 통합 테스트 수행 완료
  - CREATE TABLE → INSERT → SELECT → UPDATE → DELETE → DROP TABLE 전체 흐름 정상 동작 확인
```
$ pytest tests/ -v
48 passed
```


## ✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
- `shared/db/`는 인프라 래퍼만 제공하며, 테이블 스키마 정의는 각 모듈에서 담당합니다.
- 커넥션 풀 설정값(`pool_size=5`, `max_overflow=2`, `pool_recycle=1800`)은 Cloud SQL 권장 기본값을 따랐습니다. 트래픽 패턴에 따라 조정이 필요할 수 있습니다.
- `fetch_one()`, `fetch_all()`은 `engine.connect()` (autocommit 아님)을, `execute()`와 `execute_ddl()`은 `engine.begin()` (자동 커밋/롤백)을 사용합니다.
