### PR TITLE
[Feature] Cloud Storage(GCS) 연결 관리 및 범용 파일 유틸리티 구현 (#7)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest>=7.0
 google-genai>=1.0
 cloud-sql-python-connector[pg8000]>=1.0
 sqlalchemy>=2.0
+google-cloud-storage>=2.0

--- a/shared/storage/gcs_client.py
+++ b/shared/storage/gcs_client.py
@@ -1,0 +1,233 @@
+"""Google Cloud Storage 연결 관리 및 범용 파일 유틸리티.
+
+사용 예
+-------
+업로드 (바이트):
+    >>> from shared.storage.gcs_client import get_gcs_client
+    >>> gcs = get_gcs_client()
+    >>> gcs.upload_bytes("reports/hello.txt", b"Hello!", "text/plain")
+
+업로드 (로컬 파일):
+    >>> gcs.upload_file("reports/data.csv", "/tmp/data.csv", "text/csv")
+
+다운로드 (바이트):
+    >>> data = gcs.download_bytes("reports/hello.txt")
+
+다운로드 (로컬 파일):
+    >>> gcs.download_file("reports/data.csv", "/tmp/downloaded.csv")
+
+삭제:
+    >>> gcs.delete("reports/hello.txt")
+
+존재 확인:
+    >>> gcs.exists("reports/hello.txt")
+    True
+
+목록 조회:
+    >>> gcs.list_blobs("reports/")
+    ['reports/hello.txt', 'reports/data.csv']
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from google.cloud import storage
+
+from shared.config import settings
+
+
+class StorageError(RuntimeError):
+    """GCS 관련 모든 오류의 단일 타입."""
+
+
+class GCSClient:
+    """Google Cloud Storage 버킷 관리 및 범용 파일 유틸리티.
+
+    ADC(Application Default Credentials)로 인증하며,
+    단일 버킷에 대한 파일 업로드·다운로드·삭제·조회 기능을 제공한다.
+    """
+
+    def __init__(self, *, bucket_name: str | None = None) -> None:
+        self._bucket_name = bucket_name or settings.gcs_bucket
+        self._client = storage.Client()
+        self._bucket = self._client.bucket(self._bucket_name)
+
+    @property
+    def bucket_name(self) -> str:
+        """현재 버킷 이름을 반환한다."""
+        return self._bucket_name
+
+    def upload_bytes(
+        self, blob_name: str, data: bytes, content_type: str = "application/octet-stream"
+    ) -> None:
+        """바이트 데이터를 GCS에 업로드한다.
+
+        Parameters
+        ----------
+        blob_name:
+            GCS 내 저장 경로. 예: ``"reports/hello.txt"``
+        data:
+            업로드할 바이트 데이터.
+        content_type:
+            MIME 타입. 기본값 ``"application/octet-stream"``.
+
+        Raises
+        ------
+        StorageError
+            업로드 중 예외 발생 시.
+        """
+        try:
+            blob = self._bucket.blob(blob_name)
+            blob.upload_from_string(data, content_type=content_type)
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
+    def upload_file(
+        self, blob_name: str, file_path: str | Path, content_type: str = "application/octet-stream"
+    ) -> None:
+        """로컬 파일을 GCS에 업로드한다.
+
+        Parameters
+        ----------
+        blob_name:
+            GCS 내 저장 경로.
+        file_path:
+            로컬 파일 경로.
+        content_type:
+            MIME 타입. 기본값 ``"application/octet-stream"``.
+
+        Raises
+        ------
+        StorageError
+            업로드 중 예외 발생 시.
+        """
+        try:
+            blob = self._bucket.blob(blob_name)
+            blob.upload_from_filename(str(file_path), content_type=content_type)
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
+    def download_bytes(self, blob_name: str) -> bytes:
+        """GCS 파일을 바이트로 다운로드한다.
+
+        Parameters
+        ----------
+        blob_name:
+            다운로드할 GCS 파일 경로.
+
+        Returns
+        -------
+        bytes
+            파일 내용.
+
+        Raises
+        ------
+        StorageError
+            다운로드 중 예외 발생 시.
+        """
+        try:
+            blob = self._bucket.blob(blob_name)
+            return blob.download_as_bytes()
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
+    def download_file(self, blob_name: str, dest_path: str | Path) -> None:
+        """GCS 파일을 로컬에 저장한다.
+
+        Parameters
+        ----------
+        blob_name:
+            다운로드할 GCS 파일 경로.
+        dest_path:
+            저장할 로컬 경로.
+
+        Raises
+        ------
+        StorageError
+            다운로드 중 예외 발생 시.
+        """
+        try:
+            blob = self._bucket.blob(blob_name)
+            blob.download_to_filename(str(dest_path))
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
+    def delete(self, blob_name: str) -> None:
+        """GCS 파일을 삭제한다.
+
+        Parameters
+        ----------
+        blob_name:
+            삭제할 GCS 파일 경로.
+
+        Raises
+        ------
+        StorageError
+            삭제 중 예외 발생 시.
+        """
+        try:
+            blob = self._bucket.blob(blob_name)
+            blob.delete()
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
+    def exists(self, blob_name: str) -> bool:
+        """GCS 파일 존재 여부를 확인한다.
+
+        Parameters
+        ----------
+        blob_name:
+            확인할 GCS 파일 경로.
+
+        Returns
+        -------
+        bool
+            파일이 존재하면 True, 없으면 False.
+
+        Raises
+        ------
+        StorageError
+            확인 중 예외 발생 시.
+        """
+        try:
+            blob = self._bucket.blob(blob_name)
+            return blob.exists()
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
+    def list_blobs(self, prefix: str = "") -> list[str]:
+        """특정 경로 아래 파일 목록을 반환한다.
+
+        Parameters
+        ----------
+        prefix:
+            조회할 경로 접두사. 예: ``"reports/"``.
+            빈 문자열이면 버킷 전체를 조회한다.
+
+        Returns
+        -------
+        list[str]
+            blob 이름 리스트.
+
+        Raises
+        ------
+        StorageError
+            조회 중 예외 발생 시.
+        """
+        try:
+            blobs = self._client.list_blobs(self._bucket_name, prefix=prefix or None)
+            return [blob.name for blob in blobs]
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
+
+_gcs_client: GCSClient | None = None
+
+
+def get_gcs_client() -> GCSClient:
+    """GCSClient 싱글턴을 반환한다. 최초 호출 시 1회만 생성."""
+    global _gcs_client  # noqa: PLW0603
+    if _gcs_client is None:
+        _gcs_client = GCSClient()
+    return _gcs_client

--- a/tests/shared/test_gcs_client.py
+++ b/tests/shared/test_gcs_client.py
@@ -1,0 +1,294 @@
+"""shared.storage.gcs_client 단위 테스트."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from shared.storage.gcs_client import GCSClient, StorageError, get_gcs_client
+
+
+def _make_client() -> GCSClient:
+    """storage.Client를 mock한 GCSClient 인스턴스를 반환한다."""
+    with patch("shared.storage.gcs_client.storage.Client") as mock_storage:
+        mock_storage.return_value = MagicMock()
+        client = GCSClient(bucket_name="test-bucket")
+    return client
+
+
+# --- StorageError ---
+
+def test_storage_error_is_runtime_error_subclass() -> None:
+    assert issubclass(StorageError, RuntimeError)
+
+
+# --- get_gcs_client (lazy factory) ---
+
+def test_get_gcs_client_returns_gcs_client_instance() -> None:
+    """get_gcs_client()가 GCSClient 인스턴스를 반환한다."""
+    import shared.storage.gcs_client as mod
+    with patch("shared.storage.gcs_client.storage.Client"):
+        mod._gcs_client = None
+        client = get_gcs_client()
+        assert isinstance(client, GCSClient)
+        mod._gcs_client = None
+
+
+def test_get_gcs_client_returns_same_instance() -> None:
+    """get_gcs_client()가 동일 인스턴스를 반환한다 (싱글턴)."""
+    import shared.storage.gcs_client as mod
+    with patch("shared.storage.gcs_client.storage.Client"):
+        mod._gcs_client = None
+        first = get_gcs_client()
+        second = get_gcs_client()
+        assert first is second
+        mod._gcs_client = None
+
+
+# --- bucket_name property ---
+
+def test_bucket_name_property() -> None:
+    """bucket_name 프로퍼티가 버킷 이름을 반환한다."""
+    client = _make_client()
+    assert client.bucket_name == "test-bucket"
+
+
+# --- upload_bytes ---
+
+def test_upload_bytes_calls_upload_from_string() -> None:
+    """upload_bytes()가 blob.upload_from_string()을 호출한다."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    client._bucket.blob.return_value = mock_blob
+
+    client.upload_bytes("test/hello.txt", b"Hello!", "text/plain")
+
+    client._bucket.blob.assert_called_once_with("test/hello.txt")
+    mock_blob.upload_from_string.assert_called_once_with(b"Hello!", content_type="text/plain")
+
+
+def test_upload_bytes_default_content_type() -> None:
+    """upload_bytes() content_type 미지정 시 기본값 사용."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    client._bucket.blob.return_value = mock_blob
+
+    client.upload_bytes("test/data.bin", b"\x00\x01")
+
+    mock_blob.upload_from_string.assert_called_once_with(
+        b"\x00\x01", content_type="application/octet-stream"
+    )
+
+
+def test_upload_bytes_wraps_exception() -> None:
+    """upload_bytes() 중 예외 발생 시 StorageError로 래핑한다."""
+    client = _make_client()
+    client._bucket.blob.side_effect = RuntimeError("업로드 실패")
+
+    with pytest.raises(StorageError) as exc_info:
+        client.upload_bytes("test/fail.txt", b"data")
+    assert "업로드 실패" in str(exc_info.value)
+
+
+def test_upload_bytes_preserves_cause() -> None:
+    """StorageError는 원본 예외를 __cause__로 보존한다."""
+    client = _make_client()
+    original = RuntimeError("원본 오류")
+    client._bucket.blob.side_effect = original
+
+    with pytest.raises(StorageError) as exc_info:
+        client.upload_bytes("test/fail.txt", b"data")
+    assert exc_info.value.__cause__ is original
+
+
+# --- upload_file ---
+
+def test_upload_file_calls_upload_from_filename() -> None:
+    """upload_file()이 blob.upload_from_filename()을 호출한다."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    client._bucket.blob.return_value = mock_blob
+
+    client.upload_file("test/data.csv", "/tmp/data.csv", "text/csv")
+
+    client._bucket.blob.assert_called_once_with("test/data.csv")
+    mock_blob.upload_from_filename.assert_called_once_with("/tmp/data.csv", content_type="text/csv")
+
+
+def test_upload_file_accepts_path_object() -> None:
+    """upload_file()이 pathlib.Path 객체를 받을 수 있다."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    client._bucket.blob.return_value = mock_blob
+
+    client.upload_file("test/data.csv", Path("/tmp/data.csv"), "text/csv")
+
+    mock_blob.upload_from_filename.assert_called_once_with("/tmp/data.csv", content_type="text/csv")
+
+
+def test_upload_file_wraps_exception() -> None:
+    """upload_file() 중 예외 발생 시 StorageError로 래핑한다."""
+    client = _make_client()
+    client._bucket.blob.side_effect = RuntimeError("파일 없음")
+
+    with pytest.raises(StorageError):
+        client.upload_file("test/fail.txt", "/tmp/nope.txt")
+
+
+# --- download_bytes ---
+
+def test_download_bytes_returns_bytes() -> None:
+    """download_bytes()가 바이트 데이터를 반환한다."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    mock_blob.download_as_bytes.return_value = b"file content"
+    client._bucket.blob.return_value = mock_blob
+
+    result = client.download_bytes("test/hello.txt")
+
+    assert result == b"file content"
+    client._bucket.blob.assert_called_once_with("test/hello.txt")
+
+
+def test_download_bytes_wraps_exception() -> None:
+    """download_bytes() 중 예외 발생 시 StorageError로 래핑한다."""
+    client = _make_client()
+    client._bucket.blob.side_effect = RuntimeError("다운로드 실패")
+
+    with pytest.raises(StorageError):
+        client.download_bytes("test/fail.txt")
+
+
+# --- download_file ---
+
+def test_download_file_calls_download_to_filename() -> None:
+    """download_file()이 blob.download_to_filename()을 호출한다."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    client._bucket.blob.return_value = mock_blob
+
+    client.download_file("test/data.csv", "/tmp/out.csv")
+
+    mock_blob.download_to_filename.assert_called_once_with("/tmp/out.csv")
+
+
+def test_download_file_accepts_path_object() -> None:
+    """download_file()이 pathlib.Path 객체를 받을 수 있다."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    client._bucket.blob.return_value = mock_blob
+
+    client.download_file("test/data.csv", Path("/tmp/out.csv"))
+
+    mock_blob.download_to_filename.assert_called_once_with("/tmp/out.csv")
+
+
+def test_download_file_wraps_exception() -> None:
+    """download_file() 중 예외 발생 시 StorageError로 래핑한다."""
+    client = _make_client()
+    client._bucket.blob.side_effect = RuntimeError("저장 실패")
+
+    with pytest.raises(StorageError):
+        client.download_file("test/fail.txt", "/tmp/out.txt")
+
+
+# --- delete ---
+
+def test_delete_calls_blob_delete() -> None:
+    """delete()가 blob.delete()를 호출한다."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    client._bucket.blob.return_value = mock_blob
+
+    client.delete("test/hello.txt")
+
+    client._bucket.blob.assert_called_once_with("test/hello.txt")
+    mock_blob.delete.assert_called_once()
+
+
+def test_delete_wraps_exception() -> None:
+    """delete() 중 예외 발생 시 StorageError로 래핑한다."""
+    client = _make_client()
+    client._bucket.blob.side_effect = RuntimeError("삭제 실패")
+
+    with pytest.raises(StorageError):
+        client.delete("test/fail.txt")
+
+
+# --- exists ---
+
+def test_exists_returns_true_when_blob_exists() -> None:
+    """exists()가 파일 존재 시 True를 반환한다."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    mock_blob.exists.return_value = True
+    client._bucket.blob.return_value = mock_blob
+
+    assert client.exists("test/hello.txt") is True
+
+
+def test_exists_returns_false_when_blob_missing() -> None:
+    """exists()가 파일 미존재 시 False를 반환한다."""
+    client = _make_client()
+    mock_blob = MagicMock()
+    mock_blob.exists.return_value = False
+    client._bucket.blob.return_value = mock_blob
+
+    assert client.exists("test/nope.txt") is False
+
+
+def test_exists_wraps_exception() -> None:
+    """exists() 중 예외 발생 시 StorageError로 래핑한다."""
+    client = _make_client()
+    client._bucket.blob.side_effect = RuntimeError("확인 실패")
+
+    with pytest.raises(StorageError):
+        client.exists("test/fail.txt")
+
+
+# --- list_blobs ---
+
+def test_list_blobs_returns_blob_names() -> None:
+    """list_blobs()가 blob 이름 리스트를 반환한다."""
+    client = _make_client()
+    mock_blob1 = MagicMock()
+    mock_blob1.name = "reports/a.txt"
+    mock_blob2 = MagicMock()
+    mock_blob2.name = "reports/b.txt"
+    client._client.list_blobs.return_value = [mock_blob1, mock_blob2]
+
+    result = client.list_blobs("reports/")
+
+    assert result == ["reports/a.txt", "reports/b.txt"]
+    client._client.list_blobs.assert_called_once_with("test-bucket", prefix="reports/")
+
+
+def test_list_blobs_empty_prefix_passes_none() -> None:
+    """list_blobs() 빈 prefix일 때 None으로 전달한다."""
+    client = _make_client()
+    client._client.list_blobs.return_value = []
+
+    result = client.list_blobs("")
+
+    assert result == []
+    client._client.list_blobs.assert_called_once_with("test-bucket", prefix=None)
+
+
+def test_list_blobs_returns_empty_list() -> None:
+    """list_blobs() 결과 없으면 빈 리스트를 반환한다."""
+    client = _make_client()
+    client._client.list_blobs.return_value = []
+
+    result = client.list_blobs("empty/")
+
+    assert result == []
+
+
+def test_list_blobs_wraps_exception() -> None:
+    """list_blobs() 중 예외 발생 시 StorageError로 래핑한다."""
+    client = _make_client()
+    client._client.list_blobs.side_effect = RuntimeError("목록 조회 실패")
+
+    with pytest.raises(StorageError):
+        client.list_blobs("fail/")


### PR DESCRIPTION
## 📝 변경 사항
- `google-cloud-storage` 라이브러리 기반 GCS 클라이언트(`GCSClient`) 구현
- 범용 파일 유틸리티 메서드 제공: `upload_bytes()`, `upload_file()`, `download_bytes()`, `download_file()`, `delete()`, `exists()`, `list_blobs()`
- 모든 GCS 오류를 `StorageError(RuntimeError)` 단일 타입으로 래핑
- `get_gcs_client()` lazy factory로 싱글턴 인스턴스 제공 (import 시점 부작용 없음)
- `requirements.txt`에 `google-cloud-storage>=2.0` 의존성 추가

## 🔗 관련 이슈
closes #7

## 📸 스크린샷 (선택)
해당 없음 (백엔드 모듈)

## 🧪 테스트
- mock 기반 단위 테스트 25건 작성 (`tests/shared/test_gcs_client.py`)
  - upload_bytes, upload_file, download_bytes, download_file, delete, exists, list_blobs
  - 예외 발생 시 StorageError 래핑 및 원본 예외 체이닝 검증
  - get_gcs_client() lazy factory 싱글턴 동작 검증
  - bucket_name 프로퍼티, 기본 content_type, Path 객체 호환성 검증
- 실제 GCS 버킷(`ade-data-bucket`) 통합 테스트 수행 완료
  - 업로드 → 존재 확인 → 다운로드 → 목록 조회 → 덮어쓰기 수정 → 삭제 전체 흐름 정상 동작 확인

```
$ pytest tests/ -v
73 passed
```

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
- `shared/storage/`는 인프라 래퍼만 제공하며, 구체적인 파일 경로·구조는 각 모듈에서 담당합니다.
- `shared/db/connection.py`, `shared/llm/gemini_client.py`와 동일한 패턴(에러 래핑, lazy factory)을 따랐습니다.
- ADC(Application Default Credentials)로 인증하므로 별도 서비스 계정 키 설정이 필요 없습니다.
