### PR TITLE
fix(data): 호/목 정규화 중복 해결

### DIFF
--- a/data/collectors/law_collector.py
+++ b/data/collectors/law_collector.py
@@ -5,12 +5,15 @@ from pathlib import Path
 from openpyxl import Workbook
 import os
 from dotenv import load_dotenv
-load_dotenv(Path(__file__).parent.parent.parent / ".env") # 프로젝트 루트의 .env 로드
+
+load_dotenv(Path(__file__).parent.parent.parent / ".env")
 OC = os.getenv("LAW_API_KEY")
 BASE_URL = "https://www.law.go.kr/DRF"
 
 # 항내용 앞 원기호(①②③...) 제거 패턴
 CIRCLE_RE = re.compile(r"^[①-⑳㉑-㉟]+\s*")
+# 호/목 내용 앞 중복 번호("1.  ", "가.  " 등) 제거 패턴
+HO_NUM_RE = re.compile(r"^[\d가-힣]+\.\s*")
 
 # ── 수집 대상 ─────────────────────────────────────────────────────────
 
@@ -202,11 +205,11 @@ def parse_law(xml_text: str):
                 호목_lines = []
                 for 호 in 항.findall("호"):
                     호번호 = 호.findtext("호번호", "").strip().rstrip(".")
-                    호내용 = 호.findtext("호내용", "").strip()
+                    호내용 = HO_NUM_RE.sub("", 호.findtext("호내용", "").strip())  # 중복 번호 제거
                     호목_lines.append(f"{호번호}. {호내용}")
                     for 목 in 호.findall("목"):
                         목번호 = 목.findtext("목번호", "").strip().rstrip(".")
-                        목내용 = 목.findtext("목내용", "").strip()
+                        목내용 = HO_NUM_RE.sub("", 목.findtext("목내용", "").strip())  # 중복 번호 제거
                         호목_lines.append(f"  {목번호}. {목내용}")
 
                 hang_rows.append({
@@ -222,11 +225,11 @@ def parse_law(xml_text: str):
             호목_lines = []
             for 호 in 단위.findall("호"):
                 호번호 = 호.findtext("호번호", "").strip().rstrip(".")
-                호내용 = 호.findtext("호내용", "").strip()
+                호내용 = HO_NUM_RE.sub("", 호.findtext("호내용", "").strip())  # 중복 번호 제거
                 호목_lines.append(f"{호번호}. {호내용}")
                 for 목 in 호.findall("목"):
                     목번호 = 목.findtext("목번호", "").strip().rstrip(".")
-                    목내용 = 목.findtext("목내용", "").strip()
+                    목내용 = HO_NUM_RE.sub("", 목.findtext("목내용", "").strip())  # 중복 번호 제거
                     호목_lines.append(f"  {목번호}. {목내용}")
             if 호목_lines:
                 hang_rows.append({


### PR DESCRIPTION
## 📝 변경 사항
- 호/목 수집에서 번호가 중복되는 이슈를 발견하고 이를 해결

## 🔗 관련 이슈
closes #14

## 📸 스크린샷 (선택)
해당없음

## 🧪 테스트
- 수집된 DB 열어서 필터링 걸어 직접 확인

## ✅ 체크리스트
- [X] 코드가 정상적으로 동작합니다.
- [X] 커밋 메시지가 컨벤션을 따릅니다.
- [X] 셀프 리뷰를 완료했습니다.
- [X] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
- 호/목 수집 시 넘버링이 중복되는 문제를 해결하기 위한 정규식이 정상 작동하는지 확인 부탁드립니다.
