### PR TITLE
Feature/12 llm으로 로톡 특약 문구 정제

### DIFF
--- a/data/processors/lawtalk_qa_processor.py
+++ b/data/processors/lawtalk_qa_processor.py
@@ -4,6 +4,8 @@ import json
 import re
 from pathlib import Path
 
+from pydantic import BaseModel, Field
+
 
 TARGET_LAWS = [
     "민법",
@@ -20,12 +22,34 @@ TARGET_LAWS = [
 ]
 
 SPECIAL_KEYWORDS = ["특약", "특약사항", "특약조항", "특약 조항"]
+RULE_BASED_FILTERED_FILES = [
+    "qa_both.json",
+    "qa_law_only.json",
+    "qa_precedent_only.json",
+]
+
+
+class ExtractedClausesResult(BaseModel):
+    """rule-based 특약 후보에서 실제 계약서 특약 문구를 고른 결과."""
+
+    extracted_clauses: list[str] = Field(
+        description=(
+            "special_clauses 안에서 실제 계약서에 존재할 만한 특약 문구만 넣습니다. "
+            "질문, 상담 요청, 배경 설명, 법률 판단 질문은 제외합니다."
+        )
+    )
 
 
 def add_unique(items, value):
     """리스트에 같은 값이 없을 때만 값을 추가한다."""
     if value not in items:
         items.append(value)
+
+
+def debug_log(enabled, message):
+    """디버그 모드일 때만 추적 로그를 출력한다."""
+    if enabled:
+        print(f"[lawtalk_qa][debug] {message}", flush=True)
 
 
 def make_law_reference(law_name, article_number, sub_article_number):
@@ -170,6 +194,38 @@ def extract_special_clauses(question_body):
     return special_clauses
 
 
+def build_clause_postprocess_prompt(special_clauses):
+    """1차 rule-based 결과의 special_clauses만 사용해 특약 후처리 프롬프트를 만든다."""
+    lines = [
+        "다음 special_clauses 목록에서 실제 계약서에 존재할 만한 특약 문구만 골라주세요.",
+        "규칙:",
+        "1. 질문자의 질문, 상담 요청, 배경 설명은 제외합니다.",
+        "2. 계약서에 실제로 적혀 있을 만한 약정 문구만 extracted_clauses에 넣습니다.",
+        "3. 원문에 없는 새로운 내용을 만들지 않습니다.",
+        "4. 문장을 다듬더라도 의미를 바꾸지 않습니다.",
+        "5. 실제 특약 문구가 없으면 extracted_clauses에 빈 리스트를 넣습니다.",
+        "",
+        "special_clauses:",
+    ]
+
+    for index, clause in enumerate(special_clauses, start=1):
+        lines.append(f"{index}. {clause}")
+
+    return "\n".join(lines)
+
+
+def extract_clauses_from_special_clauses_with_llm(special_clauses):
+    """1차 rule-based special_clauses에서 실제 계약서 특약 문구만 LLM으로 추출한다."""
+    from shared.llm.gemini_client import gemini_client
+
+    prompt = build_clause_postprocess_prompt(special_clauses)
+    result = gemini_client.generate(
+        prompt,
+        response_schema=ExtractedClausesResult,
+    )
+    return result.extracted_clauses
+
+
 def process_record(record):
     """로톡 QA 레코드 하나를 필터링하고 출력 형식으로 바꾼다."""
     question_body = record.get("question_body", "")
@@ -211,6 +267,126 @@ def write_json(file_path, records):
     """레코드 목록을 JSON 파일로 저장한다."""
     with open(file_path, "w", encoding="utf-8") as file:
         json.dump(records, file, ensure_ascii=False, indent=2)
+
+
+def load_rule_based_filtered_records(input_dir):
+    """1차 rule-based 결과 세 파일을 읽고 source 메타데이터를 붙인다."""
+    input_path = Path(input_dir)
+    records = []
+
+    for source_file in RULE_BASED_FILTERED_FILES:
+        source_path = input_path / source_file
+        source_records = read_records_from_file(source_path)
+
+        for source_position, record in enumerate(source_records, start=1):
+            merged_record = dict(record)
+            merged_record["source_file"] = source_file
+            merged_record["source_position"] = source_position
+            records.append(merged_record)
+
+    return records
+
+
+def process_rule_based_filtered_clauses(
+    input_dir="data/lawtalk_qa_filtered",
+    output_file=None,
+    clause_extractor=None,
+    debug=False,
+    limit=None,
+):
+    """1차 rule-based 결과를 LLM으로 후처리하고 매 레코드마다 결과 파일을 갱신한다."""
+    input_path = Path(input_dir)
+    output_path = (
+        Path(output_file)
+        if output_file is not None
+        else input_path / "qa_clauses_processed.json"
+    )
+    extractor = clause_extractor or extract_clauses_from_special_clauses_with_llm
+    source_records = load_rule_based_filtered_records(input_path)
+
+    if output_path.exists():
+        processed_records = read_records_from_file(output_path)
+    else:
+        processed_records = []
+
+    processed_keys = {
+        (record.get("source_file"), record.get("source_position"))
+        for record in processed_records
+    }
+    processed_count = 0
+    skipped_count = 0
+    failed_count = 0
+
+    debug_log(
+        debug,
+        (
+            f"clause_postprocess_start input_dir={input_path} "
+            f"output_file={output_path} limit={limit}"
+        ),
+    )
+
+    for record in source_records:
+        key = (record["source_file"], record["source_position"])
+
+        if key in processed_keys:
+            skipped_count = skipped_count + 1
+            debug_log(
+                debug,
+                (
+                    f"clause_postprocess_skip source_file={record['source_file']} "
+                    f"source_position={record['source_position']} reason=already_processed"
+                ),
+            )
+            continue
+
+        if limit is not None and processed_count >= limit:
+            debug_log(debug, f"clause_postprocess_limit_reached limit={limit}")
+            break
+
+        special_clauses = record.get("special_clauses", [])
+        debug_log(
+            debug,
+            (
+                f"clause_postprocess_start_record source_file={record['source_file']} "
+                f"source_position={record['source_position']} "
+                f"special_clause_count={len(special_clauses)}"
+            ),
+        )
+
+        output_record = dict(record)
+
+        try:
+            output_record["extracted_clauses"] = extractor(special_clauses)
+            output_record["clause_processing_status"] = "success"
+        except Exception as exc:
+            output_record["extracted_clauses"] = []
+            output_record["clause_processing_status"] = "failed"
+            output_record["clause_processing_error"] = str(exc)
+            failed_count = failed_count + 1
+
+        processed_records.append(output_record)
+        processed_keys.add(key)
+        processed_count = processed_count + 1
+        write_json(output_path, processed_records)
+
+        debug_log(
+            debug,
+            (
+                f"clause_postprocess_done_record source_file={record['source_file']} "
+                f"source_position={record['source_position']} "
+                f"status={output_record['clause_processing_status']} "
+                f"extracted_count={len(output_record['extracted_clauses'])}"
+            ),
+        )
+
+    debug_log(debug, "clause_postprocess_done")
+
+    return {
+        "total_records": len(source_records),
+        "processed_count": processed_count,
+        "skipped_count": skipped_count,
+        "failed_count": failed_count,
+    }
 
 
 def run(input_dir="data/lawtalk_qa", output_dir="data/lawtalk_qa_filtered"):

--- a/scripts/run_processor.py
+++ b/scripts/run_processor.py
@@ -11,16 +11,88 @@ sys.path.insert(0, PROJECT_ROOT)
 
 def run_lawtalk_qa(args):
     """로톡 QA 전처리를 실행한다."""
-    from data.processors.lawtalk_qa_processor import run
+    from data.processors.lawtalk_qa_processor import (
+        process_rule_based_filtered_clauses,
+        run,
+    )
+
+    debug = False
+    extract_clauses = False
+    limit = None
+    path_args = []
+
+    index = 0
+    while index < len(args):
+        arg = args[index]
+
+        if arg == "--extract-clauses":
+            extract_clauses = True
+            index = index + 1
+            continue
+
+        if arg == "--debug":
+            debug = True
+            index = index + 1
+            continue
+
+        if arg == "--limit":
+            if index + 1 >= len(args):
+                print("오류: --limit 뒤에는 처리할 레코드 수를 입력해야 합니다.")
+                sys.exit(1)
+
+            try:
+                limit = int(args[index + 1])
+            except ValueError:
+                print("오류: --limit 값은 정수여야 합니다.")
+                sys.exit(1)
+
+            index = index + 2
+            continue
+
+        path_args.append(arg)
+        index = index + 1
+
+    if extract_clauses:
+        input_dir = "data/lawtalk_qa_filtered"
+        output_file = None
+
+        if len(path_args) >= 1:
+            input_dir = path_args[0]
+
+        if len(path_args) >= 2:
+            output_file = path_args[1]
+
+        print(f"[lawtalk_qa] 특약 후처리 입력: {input_dir}")
+        print(
+            "[lawtalk_qa] 특약 후처리 출력: "
+            + (output_file or f"{input_dir}/qa_clauses_processed.json")
+        )
+        print(f"[lawtalk_qa] 디버그: {'사용' if debug else '미사용'}")
+        if limit is not None:
+            print(f"[lawtalk_qa] 처리 제한: {limit}건")
+
+        stats = process_rule_based_filtered_clauses(
+            input_dir,
+            output_file=output_file,
+            debug=debug,
+            limit=limit,
+        )
+
+        print("\n=== 특약 후처리 결과 요약 ===")
+        print(f"전체 레코드: {stats['total_records']}건")
+        print(f"이번 실행 처리: {stats['processed_count']}건")
+        print(f"기존 처리 건너뜀: {stats['skipped_count']}건")
+        print(f"실패: {stats['failed_count']}건")
+        return
 
     input_dir = "data/lawtalk_qa"
     output_dir = "data/lawtalk_qa_filtered"
 
-    if len(args) >= 1:
-        input_dir = args[0]
+    if len(path_args) >= 1:
+        input_dir = path_args[0]
 
-    if len(args) >= 2:
-        output_dir = args[1]
+    if len(path_args) >= 2:
+        output_dir = path_args[1]
 
     print(f"[lawtalk_qa] 입력: {input_dir}")
     print(f"[lawtalk_qa] 출력: {output_dir}")

--- a/tests/test_lawtalk_qa_processor.py
+++ b/tests/test_lawtalk_qa_processor.py
@@ -1,10 +1,18 @@
 import json
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
+import scripts.run_processor as run_processor
 from data.processors.lawtalk_qa_processor import (
+    ExtractedClausesResult,
+    build_clause_postprocess_prompt,
+    extract_clauses_from_special_clauses_with_llm,
     extract_law_references,
     extract_precedent_numbers,
     extract_special_clauses,
+    load_rule_based_filtered_records,
     process_record,
+    process_rule_based_filtered_clauses,
     run,
 )
 
@@ -19,6 +27,263 @@ def test_extract_special_clauses_only_special_sentences():
     result = extract_special_clauses(text)
 
     assert result == ["계약서 특약사항에 월세 5% 인상 조항이 있습니다."]
+
+
+def test_extracted_clauses_result_schema_accepts_clause_list():
+    result = ExtractedClausesResult(
+        extracted_clauses=["임차인은 원상복구 비용을 부담한다."]
+    )
+
+    assert result.extracted_clauses == ["임차인은 원상복구 비용을 부담한다."]
+    description = ExtractedClausesResult.model_fields["extracted_clauses"].description
+    assert "실제 계약서에 존재할 만한 특약" in description
+
+
+def test_build_clause_postprocess_prompt_uses_special_clauses_only():
+    special_clauses = [
+        "계약서 특약사항에 원상복구는 임차인이 부담한다고 적혀 있습니다.",
+        "이 특약이 민법보다 우선하나요?",
+    ]
+
+    prompt = build_clause_postprocess_prompt(special_clauses)
+
+    assert "special_clauses" in prompt
+    assert "원상복구는 임차인이 부담" in prompt
+    assert "질문 본문" not in prompt
+    assert "실제 계약서에 존재할 만한 특약" in prompt
+    assert "extracted_clauses" in prompt
+
+
+def test_extract_clauses_from_special_clauses_with_llm_uses_gemini_schema():
+    special_clauses = [
+        "계약서 특약사항에 원상복구는 임차인이 부담한다고 적혀 있습니다.",
+        "이 특약이 민법보다 우선하나요?",
+    ]
+    parsed = ExtractedClausesResult(
+        extracted_clauses=["원상복구는 임차인이 부담한다."]
+    )
+    mock_gemini_client = Mock()
+    mock_gemini_client.generate.return_value = parsed
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "shared.llm.gemini_client": SimpleNamespace(
+                gemini_client=mock_gemini_client
+            )
+        },
+    ):
+        result = extract_clauses_from_special_clauses_with_llm(special_clauses)
+
+    assert result == ["원상복구는 임차인이 부담한다."]
+    args, kwargs = mock_gemini_client.generate.call_args
+    assert kwargs["response_schema"] is ExtractedClausesResult
+    assert "special_clauses" in args[0]
+    assert "원상복구는 임차인이 부담" in args[0]
+
+
+def test_load_rule_based_filtered_records_merges_three_files_with_source_metadata(
+    tmp_path,
+):
+    input_dir = tmp_path / "lawtalk_qa_filtered"
+    input_dir.mkdir()
+
+    with open(input_dir / "qa_both.json", "w", encoding="utf-8") as file:
+        json.dump(
+            [
+                {
+                    "index": 1,
+                    "special_clauses": ["특약 A"],
+                    "law_references": ["민법 제103조"],
+                    "precedent_numbers": ["2012다28486"],
+                }
+            ],
+            file,
+            ensure_ascii=False,
+        )
+    with open(input_dir / "qa_law_only.json", "w", encoding="utf-8") as file:
+        json.dump(
+            [
+                {
+                    "index": 1,
+                    "special_clauses": ["특약 B"],
+                    "law_references": ["민법 제623조"],
+                    "precedent_numbers": [],
+                }
+            ],
+            file,
+            ensure_ascii=False,
+        )
+    with open(input_dir / "qa_precedent_only.json", "w", encoding="utf-8") as file:
+        json.dump(
+            [
+                {
+                    "index": 1,
+                    "special_clauses": ["특약 C"],
+                    "law_references": [],
+                    "precedent_numbers": ["2020가단123"],
+                }
+            ],
+            file,
+            ensure_ascii=False,
+        )
+
+    records = load_rule_based_filtered_records(input_dir)
+
+    assert [record["source_file"] for record in records] == [
+        "qa_both.json",
+        "qa_law_only.json",
+        "qa_precedent_only.json",
+    ]
+    assert [record["source_position"] for record in records] == [1, 1, 1]
+    assert records[0]["special_clauses"] == ["특약 A"]
+    assert records[1]["special_clauses"] == ["특약 B"]
+    assert records[2]["special_clauses"] == ["특약 C"]
+
+
+def test_process_rule_based_filtered_clauses_writes_after_each_record(tmp_path):
+    input_dir = tmp_path / "lawtalk_qa_filtered"
+    output_file = input_dir / "qa_clauses_processed.json"
+    input_dir.mkdir()
+
+    with open(input_dir / "qa_both.json", "w", encoding="utf-8") as file:
+        json.dump(
+            [
+                {
+                    "index": 1,
+                    "special_clauses": ["특약 A"],
+                    "law_references": ["민법 제103조"],
+                    "precedent_numbers": [],
+                },
+                {
+                    "index": 2,
+                    "special_clauses": ["특약 B"],
+                    "law_references": ["민법 제623조"],
+                    "precedent_numbers": [],
+                },
+            ],
+            file,
+            ensure_ascii=False,
+        )
+    for name in ["qa_law_only.json", "qa_precedent_only.json"]:
+        with open(input_dir / name, "w", encoding="utf-8") as file:
+            json.dump([], file)
+
+    def fake_extractor(special_clauses):
+        if special_clauses == ["특약 A"]:
+            return ["추출 A"]
+        with open(output_file, "r", encoding="utf-8") as file:
+            saved = json.load(file)
+        assert saved[0]["extracted_clauses"] == ["추출 A"]
+        return ["추출 B"]
+
+    stats = process_rule_based_filtered_clauses(
+        input_dir,
+        output_file=output_file,
+        clause_extractor=fake_extractor,
+    )
+
+    with open(output_file, "r", encoding="utf-8") as file:
+        processed = json.load(file)
+
+    assert stats == {
+        "total_records": 2,
+        "processed_count": 2,
+        "skipped_count": 0,
+        "failed_count": 0,
+    }
+    assert processed[0]["extracted_clauses"] == ["추출 A"]
+    assert processed[1]["extracted_clauses"] == ["추출 B"]
+
+
+def test_process_rule_based_filtered_clauses_skips_existing_output_records(tmp_path):
+    input_dir = tmp_path / "lawtalk_qa_filtered"
+    output_file = input_dir / "qa_clauses_processed.json"
+    input_dir.mkdir()
+
+    with open(input_dir / "qa_both.json", "w", encoding="utf-8") as file:
+        json.dump(
+            [
+                {"index": 1, "special_clauses": ["특약 A"]},
+                {"index": 2, "special_clauses": ["특약 B"]},
+            ],
+            file,
+            ensure_ascii=False,
+        )
+    for name in ["qa_law_only.json", "qa_precedent_only.json"]:
+        with open(input_dir / name, "w", encoding="utf-8") as file:
+            json.dump([], file)
+
+    with open(output_file, "w", encoding="utf-8") as file:
+        json.dump(
+            [
+                {
+                    "index": 1,
+                    "special_clauses": ["특약 A"],
+                    "source_file": "qa_both.json",
+                    "source_position": 1,
+                    "extracted_clauses": ["추출 A"],
+                    "clause_processing_status": "success",
+                }
+            ],
+            file,
+            ensure_ascii=False,
+        )
+
+    calls = []
+
+    def fake_extractor(special_clauses):
+        calls.append(special_clauses)
+        return ["추출 B"]
+
+    stats = process_rule_based_filtered_clauses(
+        input_dir,
+        output_file=output_file,
+        clause_extractor=fake_extractor,
+    )
+
+    with open(output_file, "r", encoding="utf-8") as file:
+        processed = json.load(file)
+
+    assert calls == [["특약 B"]]
+    assert stats["processed_count"] == 1
+    assert stats["skipped_count"] == 1
+    assert processed[0]["extracted_clauses"] == ["추출 A"]
+    assert processed[1]["extracted_clauses"] == ["추출 B"]
+
+
+def test_process_rule_based_filtered_clauses_respects_limit(tmp_path):
+    input_dir = tmp_path / "lawtalk_qa_filtered"
+    output_file = input_dir / "qa_clauses_processed.json"
+    input_dir.mkdir()
+
+    with open(input_dir / "qa_both.json", "w", encoding="utf-8") as file:
+        json.dump(
+            [
+                {"index": 1, "special_clauses": ["특약 A"]},
+                {"index": 2, "special_clauses": ["특약 B"]},
+            ],
+            file,
+            ensure_ascii=False,
+        )
+    for name in ["qa_law_only.json", "qa_precedent_only.json"]:
+        with open(input_dir / name, "w", encoding="utf-8") as file:
+            json.dump([], file)
+
+    stats = process_rule_based_filtered_clauses(
+        input_dir,
+        output_file=output_file,
+        clause_extractor=lambda special_clauses: special_clauses,
+        limit=1,
+    )
+
+    with open(output_file, "r", encoding="utf-8") as file:
+        processed = json.load(file)
+
+    assert stats["total_records"] == 2
+    assert stats["processed_count"] == 1
+    assert len(processed) == 1
+    assert processed[0]["extracted_clauses"] == ["특약 A"]
 
 
 def test_extract_law_references_with_article():
@@ -153,3 +418,41 @@ def test_run_writes_three_output_files(tmp_path):
     assert both[0]["index"] == 1
     assert law_only[0]["index"] == 2
     assert precedent_only[0]["index"] == 3
+
+
+def test_run_lawtalk_qa_extract_clauses_option(monkeypatch):
+    calls = []
+
+    def fake_process(input_dir, output_file=None, debug=False, limit=None):
+        calls.append((input_dir, output_file, debug, limit))
+        return {
+            "total_records": 3,
+            "processed_count": 2,
+            "skipped_count": 1,
+            "failed_count": 0,
+        }
+
+    monkeypatch.setattr(
+        "data.processors.lawtalk_qa_processor.process_rule_based_filtered_clauses",
+        fake_process,
+    )
+
+    run_processor.run_lawtalk_qa(
+        [
+            "--extract-clauses",
+            "data/lawtalk_qa_filtered",
+            "data/lawtalk_qa_filtered/qa_clauses_processed.json",
+            "--debug",
+            "--limit",
+            "2",
+        ]
+    )
+
+    assert calls == [
+        (
+            "data/lawtalk_qa_filtered",
+            "data/lawtalk_qa_filtered/qa_clauses_processed.json",
+            True,
+            2,
+        )
+    ]


### PR DESCRIPTION
## 📝 변경 사항
- rule-based 전처리 결과 파일의 `special_clauses`를 Gemini로 후처리하는 프로세서를 추가했습니다.
- `qa_clauses_processed.json`에 기존 레코드 필드와 `source_file`, `source_position`, `extracted_clauses`, 처리 상태를 함께 저장하도록 했습니다.
- `lawtalk_qa` 실행 경로에 `--extract-clauses`, `--debug`, `--limit` 옵션을 추가했습니다.
- 후처리 스키마, 프롬프트, 세 파일 로딩, 점진 저장, 재실행 건너뛰기, CLI 옵션 테스트를 추가했습니다.

## 🔗 관련 이슈
closes #12

## 📸 스크린샷 (선택)
<!-- UI 변경이 있는 경우 Before/After 스크린샷을 첨부해주세요. -->
| Before | After |
|--------|-------|
|        |       |

## 🧪 테스트
- `conda run -n capstone python -m pytest`
- 실제 Gemini 호출 smoke test: `lawtalk_qa --extract-clauses --debug --limit 3`

## ✅ 체크리스트
<!-- 아래 항목을 모두 확인한 후 리뷰를 요청해주세요. -->
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 추가/수정했습니다 (해당되는 경우).
- [x] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
- 출력 파일은 현재 데이터 크기를 고려해 레코드 처리마다 전체 JSON을 다시 쓰는 단순한 방식으로 구현했습니다.
- 전체 LLM 실행 전에는 `--limit`으로 일부 항목만 먼저 확인할 수 있습니다.