### PR TITLE
feat(db): 법령 CSV 적재 기능 추가

### DIFF
--- a/infra/cloud_sql/init_law_chunks.sql
+++ b/infra/cloud_sql/init_law_chunks.sql
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS law_child (
     article_no TEXT NOT NULL,
     paragraph_no INTEGER,
     child_text TEXT NOT NULL,
-    embedding vector(768)
+    embed_vertex vector(3072),
+    embed_kure vector(1024)
 );
 
 CREATE INDEX IF NOT EXISTS idx_law_parent_law_article

--- a/infra/cloud_sql/init_law_chunks.sql
+++ b/infra/cloud_sql/init_law_chunks.sql
@@ -1,0 +1,41 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS law_parent (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    article_key TEXT NOT NULL UNIQUE,
+    law_name TEXT NOT NULL,
+    law_abbr TEXT,
+    ministry TEXT NOT NULL,
+    enforcement_date DATE NOT NULL,
+    article_no TEXT NOT NULL,
+    article_title TEXT,
+    article_date DATE NOT NULL,
+    is_amended BOOLEAN NOT NULL DEFAULT FALSE,
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    parent_text TEXT NOT NULL,
+    is_article_only BOOLEAN NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS law_child (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    clause_key TEXT NOT NULL UNIQUE,
+    article_key TEXT NOT NULL,
+    parent_id BIGINT NOT NULL REFERENCES law_parent(id) ON DELETE CASCADE,
+    law_name TEXT NOT NULL,
+    article_no TEXT NOT NULL,
+    paragraph_no INTEGER,
+    child_text TEXT NOT NULL,
+    embedding vector(768)
+);
+
+CREATE INDEX IF NOT EXISTS idx_law_parent_law_article
+    ON law_parent (law_name, article_no);
+
+CREATE INDEX IF NOT EXISTS idx_law_parent_is_deleted
+    ON law_parent (is_deleted);
+
+CREATE INDEX IF NOT EXISTS idx_law_child_article_key
+    ON law_child (article_key);
+
+CREATE INDEX IF NOT EXISTS idx_law_child_parent_id
+    ON law_child (parent_id);

--- a/scripts/load_law_chunks.py
+++ b/scripts/load_law_chunks.py
@@ -303,7 +303,7 @@ def load_law_chunks(
             article_key = row[1]
             parent_ids[article_key] = parent_id
 
-        # 4. embedding은 CSV에 없으므로 여기서는 넣지 않는다.
+        # 4. 임베딩 컬럼은 CSV에 없으므로 여기서는 넣지 않는다.
         mapped_children = []
         for row in child_rows:
             parent_id = parent_ids[row["article_key"]]
@@ -347,7 +347,7 @@ def main() -> None:
     )
     print(f"law_parent loaded: {stats['parent_count']}")
     print(f"law_child loaded: {stats['child_count']}")
-    print("embedding column remains NULL until the embedding batch runs")
+    print("embed_vertex and embed_kure columns remain NULL until embedding batches run")
 
 
 if __name__ == "__main__":

--- a/scripts/load_law_chunks.py
+++ b/scripts/load_law_chunks.py
@@ -1,0 +1,354 @@
+"""법령 parent/child CSV를 DB에 적재하기 위한 도우미 함수."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+# 이 파일은 `python scripts/load_law_chunks.py`처럼 직접 실행한다.
+# 그 경우 Python 경로가 scripts/로 잡혀 shared/ 패키지를 못 찾을 수 있다.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+DEFAULT_PARENT_CSV = PROJECT_ROOT / "data" / "law_chunks" / "law_parent.csv"
+DEFAULT_CHILD_CSV = PROJECT_ROOT / "data" / "law_chunks" / "law_child.csv"
+
+EXPECTED_PARENT_COLUMNS = [
+    "article_key",
+    "law_name",
+    "law_abbr",
+    "ministry",
+    "enforcement_date",
+    "article_no",
+    "article_title",
+    "article_date",
+    "is_amended",
+    "is_deleted",
+    "parent_text",
+    "is_article_only",
+]
+
+EXPECTED_CHILD_COLUMNS = [
+    "clause_key",
+    "article_key",
+    "law_name",
+    "article_no",
+    "paragraph_no",
+    "child_text",
+]
+
+PARENT_DB_COLUMNS = [
+    "article_key",
+    "law_name",
+    "law_abbr",
+    "ministry",
+    "enforcement_date",
+    "article_no",
+    "article_title",
+    "article_date",
+    "is_amended",
+    "is_deleted",
+    "parent_text",
+    "is_article_only",
+]
+
+CHILD_DB_COLUMNS = [
+    "clause_key",
+    "article_key",
+    "parent_id",
+    "law_name",
+    "article_no",
+    "paragraph_no",
+    "child_text",
+]
+
+
+def parse_date_yyyymmdd(value: str) -> date:
+    """CSV의 YYYYMMDD 문자열을 DB date 타입에 맞는 값으로 바꾼다."""
+    if len(value) != 8 or not value.isdigit():
+        raise ValueError(f"date must be YYYYMMDD: {value!r}")
+
+    year = int(value[:4])
+    month = int(value[4:6])
+    day = int(value[6:8])
+    return date(year, month, day)
+
+
+def parse_bool_flag(value: str) -> bool:
+    """CSV의 0/1 값을 Python boolean 값으로 바꾼다."""
+    if value == "1":
+        return True
+    if value == "0":
+        return False
+
+    raise ValueError(f"boolean flag must be 0 or 1: {value!r}")
+
+
+def to_nullable_text(value: str) -> str | None:
+    """빈 문자열은 DB에 NULL로 저장하기 위해 None으로 바꾼다."""
+    if value == "":
+        return None
+    return value
+
+
+def to_nullable_int(value: str) -> int | None:
+    """비어 있을 수 있는 숫자 문자열을 int 또는 None으로 바꾼다."""
+    if value == "":
+        return None
+    return int(value)
+
+
+def make_postgres_copy_stream(
+    rows: list[dict[str, Any]],
+    columns: list[str],
+) -> io.StringIO:
+    """Postgres COPY에 넘길 CSV 문자열을 만든다."""
+    stream = io.StringIO()
+    writer = csv.writer(stream)
+
+    for row in rows:
+        values = []
+        for column in columns:
+            value = row[column]
+
+            if value is None:
+                values.append("")
+            elif isinstance(value, bool):
+                values.append("true" if value else "false")
+            elif isinstance(value, date):
+                values.append(value.isoformat())
+            else:
+                values.append(value)
+
+        writer.writerow(values)
+
+    stream.seek(0)
+    return stream
+
+
+def copy_rows(
+    raw_connection: Any,
+    table_name: str,
+    columns: list[str],
+    rows: list[dict[str, Any]],
+) -> None:
+    """pg8000의 COPY stream 기능으로 여러 row를 빠르게 적재한다."""
+    if not rows:
+        return
+
+    column_text = ", ".join(columns)
+    stream = make_postgres_copy_stream(rows, columns)
+    cursor = raw_connection.cursor()
+    cursor.execute(
+        f"COPY {table_name} ({column_text}) FROM STDIN WITH (FORMAT csv, NULL '')",
+        stream=stream,
+    )
+
+
+def read_csv(path: Path, expected_columns: list[str]) -> list[dict[str, str]]:
+    """CSV를 읽고 헤더가 예상한 컬럼과 같은지 확인한다."""
+    with path.open("r", encoding="utf-8-sig", newline="") as file:
+        reader = csv.DictReader(file)
+
+        if reader.fieldnames != expected_columns:
+            raise ValueError(
+                f"{path} columns mismatch: expected {expected_columns}, "
+                f"got {reader.fieldnames}"
+            )
+
+        rows = []
+        for row in reader:
+            rows.append(row)
+
+    return rows
+
+
+def _find_duplicates(values: list[str]) -> list[str]:
+    """중복된 값을 처음 발견한 순서대로 반환한다."""
+    seen = set()
+    duplicates = []
+
+    for value in values:
+        if value in seen:
+            if value not in duplicates:
+                duplicates.append(value)
+        seen.add(value)
+
+    return duplicates
+
+
+def validate_rows(
+    parent_rows: list[dict[str, str]],
+    child_rows: list[dict[str, str]],
+) -> None:
+    """CSV row들이 DB에 들어가기 전에 기본 조건을 만족하는지 확인한다."""
+    article_keys = []
+    for row in parent_rows:
+        article_keys.append(row["article_key"])
+
+    clause_keys = []
+    for row in child_rows:
+        clause_keys.append(row["clause_key"])
+
+    duplicate_article_keys = _find_duplicates(article_keys)
+    if duplicate_article_keys:
+        raise ValueError(f"duplicate article_key: {duplicate_article_keys[:5]}")
+
+    duplicate_clause_keys = _find_duplicates(clause_keys)
+    if duplicate_clause_keys:
+        raise ValueError(f"duplicate clause_key: {duplicate_clause_keys[:5]}")
+
+    # child는 반드시 parent 조문 아래에 있어야 parent_id를 만들 수 있다.
+    parent_key_set = set(article_keys)
+    missing_parent_keys = []
+    for row in child_rows:
+        article_key = row["article_key"]
+        if article_key not in parent_key_set:
+            if article_key not in missing_parent_keys:
+                missing_parent_keys.append(article_key)
+
+    if missing_parent_keys:
+        raise ValueError(f"missing parent article_key: {missing_parent_keys[:5]}")
+
+    # DB 타입으로 변환하기 전에 날짜와 boolean 형식을 미리 확인한다.
+    for row in parent_rows:
+        parse_date_yyyymmdd(row["enforcement_date"])
+        parse_date_yyyymmdd(row["article_date"])
+        parse_bool_flag(row["is_amended"])
+        parse_bool_flag(row["is_deleted"])
+        parse_bool_flag(row["is_article_only"])
+
+    # paragraph_no는 항이 없으면 비어 있고, 있으면 숫자여야 한다.
+    for row in child_rows:
+        to_nullable_int(row["paragraph_no"])
+
+
+def map_parent_row(row: dict[str, str]) -> dict[str, Any]:
+    """parent CSV 한 행을 DB insert에 사용할 값으로 바꾼다."""
+    return {
+        "article_key": row["article_key"],
+        "law_name": row["law_name"],
+        "law_abbr": to_nullable_text(row["law_abbr"]),
+        "ministry": row["ministry"],
+        "enforcement_date": parse_date_yyyymmdd(row["enforcement_date"]),
+        "article_no": row["article_no"],
+        "article_title": to_nullable_text(row["article_title"]),
+        "article_date": parse_date_yyyymmdd(row["article_date"]),
+        "is_amended": parse_bool_flag(row["is_amended"]),
+        "is_deleted": parse_bool_flag(row["is_deleted"]),
+        "parent_text": row["parent_text"],
+        "is_article_only": parse_bool_flag(row["is_article_only"]),
+    }
+
+
+def map_child_row(row: dict[str, str], parent_id: int) -> dict[str, Any]:
+    """child CSV 한 행에 DB parent_id를 붙여 insert 값으로 바꾼다."""
+    return {
+        "clause_key": row["clause_key"],
+        "article_key": row["article_key"],
+        "parent_id": parent_id,
+        "law_name": row["law_name"],
+        "article_no": row["article_no"],
+        "paragraph_no": to_nullable_int(row["paragraph_no"]),
+        "child_text": row["child_text"],
+    }
+
+
+def load_law_chunks(
+    parent_csv: Path = DEFAULT_PARENT_CSV,
+    child_csv: Path = DEFAULT_CHILD_CSV,
+    *,
+    truncate: bool = False,
+) -> dict[str, int]:
+    """법령 parent/child CSV를 DB에 적재한다."""
+    from shared.db.connection import get_db_client
+
+    # 1. CSV를 읽고 DB에 넣기 전에 기본 형식을 확인한다.
+    parent_rows = read_csv(parent_csv, EXPECTED_PARENT_COLUMNS)
+    child_rows = read_csv(child_csv, EXPECTED_CHILD_COLUMNS)
+    validate_rows(parent_rows, child_rows)
+
+    db = get_db_client()
+    raw_connection = db.engine.raw_connection()
+
+    try:
+        cursor = raw_connection.cursor()
+
+        if truncate:
+            # 재적재할 때는 child가 parent를 참조하므로 두 테이블을 같이 비운다.
+            cursor.execute("TRUNCATE TABLE law_child, law_parent RESTART IDENTITY CASCADE")
+
+        # 2. child가 parent_id를 필요로 하므로 parent를 먼저 넣는다.
+        mapped_parents = []
+        for row in parent_rows:
+            mapped_parents.append(map_parent_row(row))
+
+        print(f"copying law_parent rows: {len(mapped_parents)}", flush=True)
+        copy_rows(raw_connection, "law_parent", PARENT_DB_COLUMNS, mapped_parents)
+
+        # 3. article_key 기준으로 parent id를 찾는다.
+        cursor.execute("SELECT id, article_key FROM law_parent")
+        parent_id_rows = cursor.fetchall()
+        parent_ids = {}
+        for row in parent_id_rows:
+            parent_id = row[0]
+            article_key = row[1]
+            parent_ids[article_key] = parent_id
+
+        # 4. embedding은 CSV에 없으므로 여기서는 넣지 않는다.
+        mapped_children = []
+        for row in child_rows:
+            parent_id = parent_ids[row["article_key"]]
+            mapped_children.append(map_child_row(row, parent_id=parent_id))
+
+        print(f"copying law_child rows: {len(mapped_children)}", flush=True)
+        copy_rows(raw_connection, "law_child", CHILD_DB_COLUMNS, mapped_children)
+        raw_connection.commit()
+    except Exception:
+        raw_connection.rollback()
+        raise
+    finally:
+        raw_connection.close()
+
+    return {
+        "parent_count": len(parent_rows),
+        "child_count": len(child_rows),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    """CLI 인자를 읽는다."""
+    parser = argparse.ArgumentParser(description="Load law chunk CSV files into DB")
+    parser.add_argument("--parent-csv", type=Path, default=DEFAULT_PARENT_CSV)
+    parser.add_argument("--child-csv", type=Path, default=DEFAULT_CHILD_CSV)
+    parser.add_argument(
+        "--truncate",
+        action="store_true",
+        help="Clear law_child and law_parent before loading",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI 실행 함수."""
+    args = parse_args()
+    stats = load_law_chunks(
+        parent_csv=args.parent_csv,
+        child_csv=args.child_csv,
+        truncate=args.truncate,
+    )
+    print(f"law_parent loaded: {stats['parent_count']}")
+    print(f"law_child loaded: {stats['child_count']}")
+    print("embedding column remains NULL until the embedding batch runs")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_law_chunks_loader.py
+++ b/tests/test_law_chunks_loader.py
@@ -193,6 +193,19 @@ def test_map_child_row_converts_paragraph_no():
     assert mapped["parent_id"] == 10
     assert mapped["paragraph_no"] == 1
     assert "embedding" not in mapped
+    assert "embed_vertex" not in mapped
+    assert "embed_kure" not in mapped
+
+
+def test_law_child_schema_has_separate_embedding_columns():
+    root = Path(__file__).resolve().parents[1]
+    schema = root / "infra" / "cloud_sql" / "init_law_chunks.sql"
+
+    sql = schema.read_text(encoding="utf-8")
+
+    assert "embedding vector(768)" not in sql
+    assert "embed_vertex vector(3072)" in sql
+    assert "embed_kure vector(1024)" in sql
 
 
 def test_real_law_chunk_csv_files_are_loadable():

--- a/tests/test_law_chunks_loader.py
+++ b/tests/test_law_chunks_loader.py
@@ -1,0 +1,231 @@
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from scripts.load_law_chunks import (
+    EXPECTED_CHILD_COLUMNS,
+    EXPECTED_PARENT_COLUMNS,
+    make_postgres_copy_stream,
+    map_child_row,
+    map_parent_row,
+    parse_bool_flag,
+    parse_date_yyyymmdd,
+    read_csv,
+    to_nullable_int,
+    to_nullable_text,
+    validate_rows,
+)
+
+
+def test_parse_date_yyyymmdd():
+    assert parse_date_yyyymmdd("20260102").isoformat() == "2026-01-02"
+
+
+def test_parse_date_yyyymmdd_rejects_bad_value():
+    with pytest.raises(ValueError, match="YYYYMMDD"):
+        parse_date_yyyymmdd("2026-01-02")
+
+
+def test_parse_bool_flag():
+    assert parse_bool_flag("1") is True
+    assert parse_bool_flag("0") is False
+
+
+def test_parse_bool_flag_rejects_bad_value():
+    with pytest.raises(ValueError, match="0 or 1"):
+        parse_bool_flag("true")
+
+
+def test_to_nullable_text():
+    assert to_nullable_text("") is None
+    assert to_nullable_text("주택임대차법") == "주택임대차법"
+
+
+def test_to_nullable_int():
+    assert to_nullable_int("") is None
+    assert to_nullable_int("12") == 12
+
+
+def test_make_postgres_copy_stream_converts_values_for_copy():
+    rows = [
+        {
+            "name": "민법",
+            "empty_value": None,
+            "enabled": True,
+            "disabled": False,
+            "created_date": parse_date_yyyymmdd("20260102"),
+        }
+    ]
+
+    stream = make_postgres_copy_stream(
+        rows,
+        ["name", "empty_value", "enabled", "disabled", "created_date"],
+    )
+
+    assert stream.getvalue() == "민법,,true,false,2026-01-02\r\n"
+
+
+def test_validate_rows_accepts_matching_parent_child_keys():
+    parents = [
+        {
+            "article_key": "주택임대차보호법_제3조",
+            "law_name": "주택임대차보호법",
+            "law_abbr": "주택임대차법",
+            "ministry": "법무부",
+            "enforcement_date": "20260102",
+            "article_no": "3",
+            "article_title": "대항력 등",
+            "article_date": "20260102",
+            "is_amended": "0",
+            "is_deleted": "0",
+            "parent_text": "대항력 등 제3조(대항력 등)",
+            "is_article_only": "0",
+        }
+    ]
+    children = [
+        {
+            "clause_key": "주택임대차보호법_제3조_제1항",
+            "article_key": "주택임대차보호법_제3조",
+            "law_name": "주택임대차보호법",
+            "article_no": "3",
+            "paragraph_no": "1",
+            "child_text": "임대차는 그 등기가 없는 경우에도 효력이 생긴다.",
+        }
+    ]
+
+    validate_rows(parents, children)
+
+
+def test_validate_rows_rejects_duplicate_article_key():
+    parents = [
+        {
+            "article_key": "민법_제1조",
+            "law_name": "민법",
+            "law_abbr": "",
+            "ministry": "법무부",
+            "enforcement_date": "20260102",
+            "article_no": "1",
+            "article_title": "목적",
+            "article_date": "20260102",
+            "is_amended": "0",
+            "is_deleted": "0",
+            "parent_text": "목적",
+            "is_article_only": "1",
+        },
+        {
+            "article_key": "민법_제1조",
+            "law_name": "민법",
+            "law_abbr": "",
+            "ministry": "법무부",
+            "enforcement_date": "20260102",
+            "article_no": "1",
+            "article_title": "목적",
+            "article_date": "20260102",
+            "is_amended": "0",
+            "is_deleted": "0",
+            "parent_text": "목적",
+            "is_article_only": "1",
+        },
+    ]
+
+    with pytest.raises(ValueError, match="duplicate article_key"):
+        validate_rows(parents, [])
+
+
+def test_validate_rows_rejects_child_without_parent():
+    parents = []
+    children = [
+        {
+            "clause_key": "민법_제1조",
+            "article_key": "민법_제1조",
+            "law_name": "민법",
+            "article_no": "1",
+            "paragraph_no": "",
+            "child_text": "내용",
+        }
+    ]
+
+    with pytest.raises(ValueError, match="missing parent article_key"):
+        validate_rows(parents, children)
+
+
+def test_map_parent_row_converts_csv_types():
+    row = {
+        "article_key": "주택임대차보호법_제1조",
+        "law_name": "주택임대차보호법",
+        "law_abbr": "",
+        "ministry": "법무부",
+        "enforcement_date": "20260102",
+        "article_no": "1",
+        "article_title": "",
+        "article_date": "20260102",
+        "is_amended": "0",
+        "is_deleted": "1",
+        "parent_text": "제1조 삭제 <1989.12.30>",
+        "is_article_only": "1",
+    }
+
+    mapped = map_parent_row(row)
+
+    assert mapped["law_abbr"] is None
+    assert mapped["article_title"] is None
+    assert mapped["enforcement_date"].isoformat() == "2026-01-02"
+    assert mapped["article_date"].isoformat() == "2026-01-02"
+    assert mapped["is_amended"] is False
+    assert mapped["is_deleted"] is True
+    assert mapped["is_article_only"] is True
+
+
+def test_map_child_row_converts_paragraph_no():
+    row = {
+        "clause_key": "주택임대차보호법_제3조_제1항",
+        "article_key": "주택임대차보호법_제3조",
+        "law_name": "주택임대차보호법",
+        "article_no": "3",
+        "paragraph_no": "1",
+        "child_text": "내용",
+    }
+
+    mapped = map_child_row(row, parent_id=10)
+
+    assert mapped["parent_id"] == 10
+    assert mapped["paragraph_no"] == 1
+    assert "embedding" not in mapped
+
+
+def test_real_law_chunk_csv_files_are_loadable():
+    root = Path(__file__).resolve().parents[1]
+    parent_csv = root / "data" / "law_chunks" / "law_parent.csv"
+    child_csv = root / "data" / "law_chunks" / "law_child.csv"
+
+    parents = read_csv(parent_csv, EXPECTED_PARENT_COLUMNS)
+    children = read_csv(child_csv, EXPECTED_CHILD_COLUMNS)
+
+    validate_rows(parents, children)
+
+    assert len(parents) == 8646
+    assert len(children) == 16145
+
+
+def test_script_direct_run_can_import_project_modules():
+    root = Path(__file__).resolve().parents[1]
+    script = root / "scripts" / "load_law_chunks.py"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--parent-csv",
+            str(root / "missing_parent.csv"),
+            "--child-csv",
+            str(root / "missing_child.csv"),
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "No module named 'shared'" not in result.stderr


### PR DESCRIPTION
## 📝 변경 사항
- `law_parent`, `law_child` 테이블 스키마를 추가했습니다.
- `law_parent.csv`, `law_child.csv`를 DB에 적재하는 스크립트를 추가했습니다.
- CSV의 `article_key`, `clause_key`를 기준으로 중복을 막고, child 데이터는 parent와 연결되도록 했습니다.
- embedding 컬럼은 만들었지만, 값은 나중에 따로 넣을 수 있도록 비워두었습니다.

## 🔗 관련 이슈
closes #9 

## 📸 스크린샷 (선택)
<!-- UI 변경이 있는 경우 Before/After 스크린샷을 첨부해주세요. -->
| Before | After |
|--------|-------|
|        |       |

## 🧪 테스트
- 스크립트를 실행해서 `law_parent`, `law_child` 데이터가 DB에 정상적으로 업로드되는 것을 확인했습니다.

## ✅ 체크리스트
<!-- 아래 항목을 모두 확인한 후 리뷰를 요청해주세요. -->
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 추가/수정했습니다 (해당되는 경우).
- [x] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
- CSV 구조에 맞게 DB 스키마가 구성되었는지 확인 부탁드립니다.
- `article_key`, `clause_key`, `parent_id` 연결 방식이 적절한지 봐주시면 좋겠습니다.