### PR TITLE
feat(data): 판례 수집기 및 키워드 빈도 분석 스크립트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ data/raw/
 data/lawtalk_qa_filtered/
 data/law_chunks/
 evaluation/results/
+keyword_analysis_output/
+output/
 
 # Python
 __pycache__/

--- a/data/collectors/case_collector.py
+++ b/data/collectors/case_collector.py
@@ -1,0 +1,585 @@
+import time
+import json
+import logging
+import urllib.parse
+import requests
+import urllib3
+from dataclasses import dataclass, asdict, field
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, Tuple, Any
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+# =========================================================
+# 1. 사용자 설정
+# =========================================================
+
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env")
+
+OC         = os.getenv("LAW_API_KEY")
+BASE_URL   = "https://www.law.go.kr/DRF"
+SEARCH_URL = f"{BASE_URL}/lawSearch.do"
+DETAIL_URL = f"{BASE_URL}/lawService.do"
+
+DISPLAY     = 100
+SLEEP_SEC   = 0.2
+TIMEOUT_SEC = 15
+
+MIN_LIST_HIT_COUNT   = 2
+MIN_DETAIL_HIT_COUNT = 2
+
+MAX_RESULTS_PER_LAW  = None    # 법령별 최대 수집 건수 (None = 무제한)
+
+_BASE = Path(__file__).resolve().parent.parent.parent  # data/collectors → data → 루트
+OUTPUT_JSON  = str(_BASE / "output" / "housing_precedents_final.json")
+OUTPUT_JSONL = str(_BASE / "output" / "housing_precedents_final.jsonl")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+_SESSION        = requests.Session()
+_SESSION.verify = False
+
+
+# =========================================================
+# 2. JO 법령별 정의
+# =========================================================
+
+FULL_COLLECT_JO_MAP: Dict[str, str] = {
+    "주택임대차보호법": "주택임대차보호법",
+}
+
+FILTER_COLLECT_JO_MAP: Dict[str, str] = {
+    "민법":               "민법",
+    "부동산등기법":        "부동산등기법",
+    "공인중개사법":        "공인중개사법",
+    "화물자동차운수사업법": "화물자동차운수사업법",
+    "민사소송법":          "민사소송법",
+    "민사조정법":          "민사조정법",
+    "민사집행법":          "민사집행법",
+    "소액사건심판법":       "소액사건심판법",
+    "공동주택관리법":       "공동주택관리법",
+    "주민등록법":          "주민등록법",
+}
+
+
+# =========================================================
+# 3. 주택임대차 콘텐츠 키워드
+# =========================================================
+
+HOUSING_LEASE_CONTENT_KEYWORDS: List[str] = [
+    "주택임대차", "임대차", "전세", "월세", "임차인", "임대인", "주거용",
+    "임차보증금", "임대차보증금", "보증금반환", "보증금증액", "보증금감액",
+    "대항력", "확정일자", "우선변제", "최우선변제", "소액임차인", "선순위",
+    "점유", "전입신고", "주민등록", "인도",
+    "계약갱신", "갱신거절", "묵시갱신", "해지통지", "차임연체",
+    "임차권등기", "임차권양도", "전대",
+    "근저당", "저당", "경락", "낙찰", "압류", "담보", "배당", "경매",
+    "거소", "경료", "원상회복", "수선의무", "필요비", "유익비",
+]
+
+
+# =========================================================
+# 4. 데이터 모델
+# =========================================================
+
+@dataclass
+class Precedent:
+    # API 원본 필드
+    판례일련번호: str
+    사건명:       str
+    사건번호:     str
+    선고일자:     str
+    선고:         str
+    법원명:       str
+    법원종류코드: str
+    판결유형:     str
+    판시사항:     str
+    판결요지:     str
+    참조조문:     str
+    참조판례:     str
+    판례내용:     str
+
+    # 사용자 생성 필드
+    최초포착법령:  str
+    최초JO값:     str
+    검색법령목록:  List[str]
+    JO값목록:     List[str]
+    매칭키워드목록: List[str]
+    목록히트수최대: int
+    상세히트수:    int
+
+
+# =========================================================
+# 5. 공통 유틸
+# =========================================================
+
+def _normalize_to_list(value: Any) -> List[dict]:
+    if not value:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        return [value]
+    return []
+
+
+def _safe_int(x: Any, default: int = 0) -> int:
+    try:
+        return int(x)
+    except Exception:
+        return default
+
+
+# =========================================================
+# 6. HTTP 유틸
+# =========================================================
+
+def _get_json(url: str) -> dict:
+    for attempt in range(3):
+        try:
+            resp = _SESSION.get(url, timeout=TIMEOUT_SEC)
+            resp.raise_for_status()
+            return resp.json()
+
+        except requests.exceptions.Timeout:
+            log.warning("Timeout (시도 %d/3) | %s", attempt + 1, url)
+            time.sleep(1.0 * (attempt + 1))
+
+        except requests.exceptions.ConnectionError as e:
+            log.error("ConnectionError | %s | %s", e, url)
+            time.sleep(1.0 * (attempt + 1))
+
+        except requests.exceptions.HTTPError as e:
+            log.error("HTTPError %s | %s", e, url)
+            return {}
+
+        except Exception as e:
+            log.error("Unknown Error %s | %s", e, url)
+            return {}
+
+    log.error("3회 재시도 실패 | %s", url)
+    return {}
+
+
+# =========================================================
+# 7. API 호출
+# =========================================================
+
+def search_page_by_jo(jo_value: str, page: int) -> dict:
+    params = {
+        "OC":      OC,
+        "target":  "prec",
+        "type":    "JSON",
+        "JO":      jo_value,
+        "display": DISPLAY,
+        "page":    page,
+    }
+    url = SEARCH_URL + "?" + urllib.parse.urlencode(params, encoding="utf-8")
+    return _get_json(url)
+
+
+def get_precedent_detail(prec_id: str) -> dict:
+    params = {
+        "OC":     OC,
+        "target": "prec",
+        "type":   "JSON",
+        "ID":     prec_id,
+    }
+    url = DETAIL_URL + "?" + urllib.parse.urlencode(params, encoding="utf-8")
+    return _get_json(url)
+
+
+# =========================================================
+# 8. 키워드 히트 필터
+# =========================================================
+
+def _combined_text_from_item(item: dict) -> str:
+    fields = [
+        item.get("사건명",   ""),
+        item.get("판시사항", ""),
+        item.get("판결요지", ""),
+        item.get("참조조문", ""),
+        item.get("참조판례", ""),
+    ]
+    return " ".join(f for f in fields if f)
+
+
+def _combined_text_from_detail(detail: dict) -> str:
+    svc = detail.get("PrecService", detail)
+    fields = [
+        svc.get("사건명",   ""),
+        svc.get("판시사항", ""),
+        svc.get("판결요지", ""),
+        svc.get("참조조문", ""),
+        svc.get("참조판례", ""),
+        svc.get("판례내용", ""),
+    ]
+    return " ".join(f for f in fields if f)
+
+
+def get_matched_keywords(text: str) -> List[str]:
+    if not text:
+        return []
+    return [kw for kw in HOUSING_LEASE_CONTENT_KEYWORDS if kw in text]
+
+
+def count_keyword_hits(text: str) -> int:
+    return len(get_matched_keywords(text))
+
+
+def passes_list_filter(item: dict) -> Tuple[bool, int, List[str]]:
+    text    = _combined_text_from_item(item)
+    matched = get_matched_keywords(text)
+    hits    = len(matched)
+    return hits >= MIN_LIST_HIT_COUNT, hits, matched
+
+
+def passes_detail_filter(detail: dict) -> Tuple[bool, int, List[str]]:
+    text    = _combined_text_from_detail(detail)
+    matched = get_matched_keywords(text)
+    hits    = len(matched)
+    return hits >= MIN_DETAIL_HIT_COUNT, hits, matched
+
+
+# =========================================================
+# 9. Precedent 생성 · 병합
+# =========================================================
+
+def build_precedent(
+    item:           dict,
+    law_name:       str,
+    jo_value:       str,
+    list_hits:      int,
+    matched_kws:    List[str],
+    detail_hits:    int = 0,
+) -> Precedent:
+    return Precedent(
+        판례일련번호  = item.get("판례일련번호", ""),
+        사건명        = item.get("사건명",       ""),
+        사건번호      = item.get("사건번호",     ""),
+        선고일자      = item.get("선고일자",     ""),
+        선고          = item.get("선고",         ""),
+        법원명        = item.get("법원명",       ""),
+        법원종류코드  = item.get("법원종류코드", ""),
+        판결유형      = item.get("판결유형",     ""),
+        판시사항      = item.get("판시사항",     ""),
+        판결요지      = item.get("판결요지",     ""),
+        참조조문      = item.get("참조조문",     ""),
+        참조판례      = item.get("참조판례",     ""),
+        판례내용      = item.get("판례내용",     ""),
+        최초포착법령   = law_name,
+        최초JO값      = jo_value,
+        검색법령목록   = [law_name],
+        JO값목록      = [jo_value],
+        매칭키워드목록 = sorted(set(matched_kws)),
+        목록히트수최대 = list_hits,
+        상세히트수     = detail_hits,
+    )
+
+
+def merge_precedent(existing: Precedent, new_p: Precedent) -> None:
+    if new_p.최초포착법령 not in existing.검색법령목록:
+        existing.검색법령목록.append(new_p.최초포착법령)
+
+    if new_p.최초JO값 not in existing.JO값목록:
+        existing.JO값목록.append(new_p.최초JO값)
+
+    existing.매칭키워드목록 = sorted(
+        set(existing.매칭키워드목록) | set(new_p.매칭키워드목록)
+    )
+    existing.목록히트수최대 = max(existing.목록히트수최대, new_p.목록히트수최대)
+    existing.상세히트수     = max(existing.상세히트수,     new_p.상세히트수)
+
+    for f in ["판례내용", "판시사항", "판결요지", "참조조문", "참조판례"]:
+        if not getattr(existing, f) and getattr(new_p, f):
+            setattr(existing, f, getattr(new_p, f))
+
+
+def overlay_detail(item: dict, detail: dict) -> dict:
+    """목록 item에 상세 조회 결과를 덮어씌워 반환."""
+    svc = detail.get("PrecService", detail)
+    if not isinstance(svc, dict):
+        return item
+    merged = dict(item)
+    for f in [
+        "사건명", "사건번호", "선고일자", "선고", "법원명",
+        "법원종류코드", "판결유형", "판시사항", "판결요지",
+        "참조조문", "참조판례", "판례내용",
+    ]:
+        if svc.get(f):
+            merged[f] = svc[f]
+    return merged
+
+
+# =========================================================
+# 10. 수집 함수 A — 전체 수집 (주택임대차보호법)
+#     [수정] 상세 API 호출 추가 — 목록만 저장하면 본문이 비어있는 문제 수정
+# =========================================================
+
+def collect_full(law_name: str, jo_value: str) -> List[Precedent]:
+    results:  List[Precedent] = []
+    seen_ids: set             = set()
+    page      = 1
+
+    log.info("[전체수집 시작] 법령=%s | JO=%s", law_name, jo_value)
+
+    while True:
+        data      = search_page_by_jo(jo_value=jo_value, page=page)
+        raw       = data.get("PrecSearch", {}).get("prec")
+        items     = _normalize_to_list(raw)
+        total_cnt = _safe_int(data.get("PrecSearch", {}).get("totalCnt", 0))
+
+        if not items:
+            log.info("  [%s] page=%d — 결과 없음, 탐색 종료", law_name, page)
+            break
+
+        for item in items:
+            prec_id = item.get("판례일련번호", "")
+            if not prec_id or prec_id in seen_ids:
+                continue
+
+            # ── [수정] 상세 API 호출해서 본문 채우기 ──
+            detail = get_precedent_detail(prec_id)
+            if detail:
+                item = overlay_detail(item, detail)
+                _, detail_hits, matched_kws = passes_detail_filter(detail)
+            else:
+                text        = _combined_text_from_item(item)
+                matched_kws = get_matched_keywords(text)
+                detail_hits = 0
+
+            time.sleep(SLEEP_SEC)
+            # ─────────────────────────────────────────
+
+            seen_ids.add(prec_id)
+            results.append(
+                build_precedent(
+                    item=item,
+                    law_name=law_name,
+                    jo_value=jo_value,
+                    list_hits=len(matched_kws),
+                    matched_kws=matched_kws,
+                    detail_hits=detail_hits,
+                )
+            )
+
+        log.info(
+            "  [%s] page=%d | 이번=%d건 | 누계=%d건 / 전체=%d건",
+            law_name, page, len(items), len(results), total_cnt,
+        )
+
+        if len(items) < DISPLAY or page * DISPLAY >= total_cnt:
+            break
+
+        page += 1
+        time.sleep(SLEEP_SEC)
+
+    log.info("[전체수집 완료] 법령=%s | 수집=%d건", law_name, len(results))
+    return results
+
+
+# =========================================================
+# 11. 수집 함수 B — 히트 필터 수집 (나머지 10개 법령)
+# =========================================================
+
+def collect_filtered(law_name: str, jo_value: str) -> List[Precedent]:
+    results:      List[Precedent] = []
+    seen_ids:     set             = set()
+    page          = 1
+    total_scanned = 0
+
+    log.info("[필터수집 시작] 법령=%s | JO=%s", law_name, jo_value)
+
+    while True:
+        if MAX_RESULTS_PER_LAW is not None and len(results) >= MAX_RESULTS_PER_LAW:
+            log.info("  [%s] 최대 수집 건수 도달 (%d건)", law_name, MAX_RESULTS_PER_LAW)
+            break
+
+        data      = search_page_by_jo(jo_value=jo_value, page=page)
+        raw       = data.get("PrecSearch", {}).get("prec")
+        items     = _normalize_to_list(raw)
+        total_cnt = _safe_int(data.get("PrecSearch", {}).get("totalCnt", 0))
+
+        if not items:
+            log.info("  [%s] page=%d — 결과 없음, 탐색 종료", law_name, page)
+            break
+
+        for item in items:
+            total_scanned += 1
+
+            prec_id = item.get("판례일련번호", "")
+            if not prec_id or prec_id in seen_ids:
+                continue
+
+            # 1차 필터: 목록 단계 키워드 히트
+            passed, list_hits, matched_kws = passes_list_filter(item)
+            if not passed:
+                continue
+
+            # 상세 API 호출 (항상 실행 — 본문 보장)
+            detail      = get_precedent_detail(prec_id)
+            detail_hits = 0
+            if detail:
+                passed_d, detail_hits, matched_kws_d = passes_detail_filter(detail)
+                if not passed_d:
+                    time.sleep(SLEEP_SEC)
+                    continue
+                matched_kws = matched_kws_d
+                item        = overlay_detail(item, detail)
+            time.sleep(SLEEP_SEC)
+
+            seen_ids.add(prec_id)
+            results.append(
+                build_precedent(
+                    item=item,
+                    law_name=law_name,
+                    jo_value=jo_value,
+                    list_hits=list_hits,
+                    matched_kws=matched_kws,
+                    detail_hits=detail_hits,
+                )
+            )
+
+            if MAX_RESULTS_PER_LAW is not None and len(results) >= MAX_RESULTS_PER_LAW:
+                break
+
+        log.info(
+            "  [%s] page=%d | 이번 검토=%d건 | 통과 누계=%d건 / 전체=%d건",
+            law_name, page, len(items), len(results), total_cnt,
+        )
+
+        if len(items) < DISPLAY or page * DISPLAY >= total_cnt:
+            break
+
+        page += 1
+        time.sleep(SLEEP_SEC)
+
+    log.info(
+        "[필터수집 완료] 법령=%s | 검토=%d건 | 통과=%d건",
+        law_name, total_scanned, len(results),
+    )
+    return results
+
+
+# =========================================================
+# 12. 저장
+# =========================================================
+
+def save_outputs(
+    precedents: List[Precedent],
+    json_path:  str = OUTPUT_JSON,
+    jsonl_path: str = OUTPUT_JSONL,
+) -> None:
+    rows = [asdict(p) for p in precedents]
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(rows, f, ensure_ascii=False, indent=2)
+
+    with open(jsonl_path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    log.info("저장 완료 → %s / %s", json_path, jsonl_path)
+
+
+# =========================================================
+# 13. 메인 파이프라인
+# =========================================================
+
+def main() -> None:
+    all_map:     Dict[str, Precedent] = {}
+    law_summary: Counter              = Counter()
+
+    # ── 1단계: 주택임대차보호법 전체 수집 ──
+    for law_name, jo_value in FULL_COLLECT_JO_MAP.items():
+        log.info("=" * 70)
+        log.info("[전체수집 법령] %s (JO=%s)", law_name, jo_value)
+
+        batch = collect_full(law_name=law_name, jo_value=jo_value)
+        law_summary[law_name] = len(batch)
+
+        for p in batch:
+            if not p.판례일련번호:
+                continue
+            if p.판례일련번호 in all_map:
+                merge_precedent(all_map[p.판례일련번호], p)
+            else:
+                all_map[p.판례일련번호] = p
+
+        log.info(
+            "[전체수집 완료] %s | batch=%d | 전체고유=%d",
+            law_name, len(batch), len(all_map),
+        )
+        time.sleep(SLEEP_SEC)
+
+    # ── 2단계: 나머지 법령 히트 필터 수집 ──
+    for law_name, jo_value in FILTER_COLLECT_JO_MAP.items():
+        log.info("=" * 70)
+        log.info("[필터수집 법령] %s (JO=%s)", law_name, jo_value)
+
+        batch  = collect_filtered(law_name=law_name, jo_value=jo_value)
+        before = len(all_map)
+        law_summary[law_name] = len(batch)
+
+        for p in batch:
+            if not p.판례일련번호:
+                continue
+            if p.판례일련번호 in all_map:
+                merge_precedent(all_map[p.판례일련번호], p)
+            else:
+                all_map[p.판례일련번호] = p
+
+        added = len(all_map) - before
+        dups  = len(batch) - added
+        log.info(
+            "[필터수집 완료] %s | batch=%d | 신규=%d | 중복병합=%d | 전체고유=%d",
+            law_name, len(batch), added, dups, len(all_map),
+        )
+        time.sleep(SLEEP_SEC)
+
+    # ── 최종 저장 ──
+    all_precedents = list(all_map.values())
+    save_outputs(all_precedents)
+
+    # ── 통계 출력 ──
+    log.info("=" * 70)
+    log.info("최종 고유 판례 수: %d건", len(all_precedents))
+
+    log.info("[법령별 수집 건수]")
+    for law, cnt in law_summary.items():
+        log.info("  %-20s %5d건", law, cnt)
+
+    log.info("[최초포착법령 기준 분포]")
+    origin = Counter(p.최초포착법령 for p in all_precedents)
+    for law, cnt in origin.most_common():
+        log.info("  %-20s %5d건", law, cnt)
+
+    log.info("[매칭 키워드 빈도 상위 20개]")
+    kw_counter: Counter = Counter()
+    for p in all_precedents:
+        for kw in p.매칭키워드목록:
+            kw_counter[kw] += 1
+    for kw, cnt in kw_counter.most_common(20):
+        log.info("  %-15s %5d건", kw, cnt)
+
+    # ── 본문 수집 현황 ──
+    empty_cnt = sum(
+        1 for p in all_precedents
+        if not p.판례내용 and not p.판시사항 and not p.판결요지
+    )
+    log.info("본문 있음: %d건 / 본문 없음: %d건", len(all_precedents) - empty_cnt, empty_cnt)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/collectors/keyword_frequency.py
+++ b/data/collectors/keyword_frequency.py
@@ -1,0 +1,419 @@
+import json
+import re
+import math
+from collections import Counter
+from pathlib import Path
+
+import pandas as pd
+
+
+# =========================================================
+# 1. 파일 경로 설정
+# =========================================================
+_BASE = Path(__file__).resolve().parent.parent.parent
+CASE_DETAILS_PATH = str(_BASE / "output" / "case_details.json")
+OUTPUT_DIR = _BASE / "keyword_analysis_output"
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+TF_OUTPUT_PATH = OUTPUT_DIR / "keyword_frequency_tf.csv"
+DF_OUTPUT_PATH = OUTPUT_DIR / "keyword_frequency_df.csv"
+RECOMMEND_OUTPUT_PATH = OUTPUT_DIR / "recommended_keywords.csv"
+
+
+# =========================================================
+# 2. 분석 설정
+# =========================================================
+USE_KIWI = True   # 설치되어 있으면 사용, 없으면 자동 fallback
+MIN_TOKEN_LEN = 2
+
+# 추천 키워드 조건
+RECOMMEND_MIN_TF = 10
+RECOMMEND_MIN_DF_RATIO = 2.0
+RECOMMEND_MAX_DF_RATIO = 45.0
+RECOMMEND_MIN_LEN = 2
+RECOMMEND_TOP_N = 80
+
+# 너무 일반적이거나 소송 절차상 반복되는 단어 제거
+STOPWORDS = {
+    "원고", "피고", "상고인", "피상고인", "항소인", "피항소인",
+    "신청인", "피신청인", "법원", "대법원", "지방법원", "고등법원",
+    "판결", "결정", "사건", "청구", "이유", "주문", "판단", "인정",
+    "관련", "경우", "부분", "내용", "사실", "의미", "대한", "해당",
+    "규정", "법률", "조문", "효력", "위반", "주장", "여부",
+    "각", "그", "이", "저", "등", "및", "수", "것", "때", "바"
+}
+
+# 추천 키워드에서는 제외할 일반어
+GENERIC_EXCLUDE = {
+    "주택", "건물", "계약", "관계", "절차", "방법", "사례",
+    "권리", "의무", "적용", "존재", "기준", "사정", "표시",
+    "민법", "민사", "취지", "목적", "소정", "적극", "소극",
+    "이전", "지위", "공시", "요건", "내용", "경우", "법률",
+    "법원", "판결", "원고", "피고", "당사자", "이유", "주문"
+}
+
+# 프로젝트상 남기고 싶은 복합명사 사전
+COMPOUND_TERMS = [
+    "주택임대차", "주택임대차보호법", "계약갱신요구권", "묵시적갱신",
+    "임차권등기명령", "우선변제권", "최우선변제권", "대항력", "확정일자",
+    "전입신고", "주민등록", "임대인", "임차인", "임대차", "보증금",
+    "임차보증금", "보증금반환", "차임", "차임연체", "전대차", "전대",
+    "원상회복", "수선의무", "필요비", "유익비", "사용수익", "명도",
+    "인도", "경매", "배당", "우선변제", "갱신거절", "임대차기간",
+    "차임증액", "전월세전환", "계약해지", "계약해제"
+]
+
+# 정리 시 제거할 패턴
+REMOVE_PATTERNS = [
+    r"제\d+조",
+    r"제\d+항",
+    r"제\d+호",
+    r"\d+년",
+    r"\d+월",
+    r"\d+일",
+]
+
+
+# =========================================================
+# 3. 형태소 분석기 준비 (선택)
+# =========================================================
+kiwi = None
+
+if USE_KIWI:
+    try:
+        from kiwipiepy import Kiwi
+        kiwi = Kiwi()
+        print("[INFO] Kiwi 형태소 분석기를 사용합니다.")
+    except Exception:
+        kiwi = None
+        print("[INFO] Kiwi를 사용할 수 없어 정규식 기반 분석으로 진행합니다.")
+else:
+    print("[INFO] 정규식 기반 분석으로 진행합니다.")
+
+
+# =========================================================
+# 4. JSON 로드
+# =========================================================
+def load_json(path: str):
+    """
+    JSON 파일을 로드한다.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+# =========================================================
+# 5. 텍스트 전처리
+# =========================================================
+def clean_text(text: str) -> str:
+    """
+    HTML/특수문자 제거 및 공백 정리
+    """
+    if not text:
+        return ""
+
+    text = str(text)
+
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"&[a-zA-Z]+;", " ", text)
+    text = re.sub(r"&#\d+;", " ", text)
+
+    for pattern in REMOVE_PATTERNS:
+        text = re.sub(pattern, " ", text)
+
+    text = re.sub(r"[^가-힣a-zA-Z0-9\s_]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+
+    return text
+
+
+# =========================================================
+# 6. 복합명사 보호
+# =========================================================
+def protect_compound_terms(text: str):
+    """
+    복합명사를 한 덩어리로 유지하기 위해 치환한다.
+    예: '계약갱신요구권' -> '__TERM0__'
+    """
+    protected_map = {}
+    protected_text = text
+
+    # 긴 단어부터 먼저 치환해야 부분 매칭 충돌이 줄어듦
+    sorted_terms = sorted(COMPOUND_TERMS, key=len, reverse=True)
+
+    for idx, term in enumerate(sorted_terms):
+        placeholder = f"__TERM{idx}__"
+        if term in protected_text:
+            protected_text = protected_text.replace(term, placeholder)
+            protected_map[placeholder] = term
+
+    return protected_text, protected_map
+
+
+def restore_protected_tokens(tokens, protected_map):
+    """
+    placeholder를 원래 복합명사로 복원
+    """
+    restored = []
+    for token in tokens:
+        restored.append(protected_map.get(token, token))
+    return restored
+
+
+# =========================================================
+# 7. 키워드 추출
+# =========================================================
+def extract_keywords_with_kiwi(text: str):
+    """
+    Kiwi 기반 키워드 추출
+    - 일반명사(NNG), 고유명사(NNP) 중심
+    - 복합명사 사전 보호 병행
+    """
+    text = clean_text(text)
+    text, protected_map = protect_compound_terms(text)
+
+    result = kiwi.tokenize(text)
+    tokens = []
+
+    for token in result:
+        form = token.form
+        tag = token.tag
+
+        # placeholder 복원
+        form = protected_map.get(form, form)
+
+        if form in STOPWORDS:
+            continue
+
+        if form in COMPOUND_TERMS:
+            tokens.append(form)
+            continue
+
+        if tag in {"NNG", "NNP"} and len(form) >= MIN_TOKEN_LEN:
+            if re.fullmatch(r"[가-힣]{2,}", form):
+                tokens.append(form)
+
+    return tokens
+
+
+def extract_keywords_with_regex(text: str):
+    """
+    형태소 분석기 없이 정규식으로 키워드 추출
+    """
+    text = clean_text(text)
+    text, protected_map = protect_compound_terms(text)
+
+    # placeholder 또는 한글 2자 이상 토큰 추출
+    tokens = re.findall(r"__TERM\d+__|[가-힣]{2,}", text)
+    tokens = restore_protected_tokens(tokens, protected_map)
+
+    results = []
+    for token in tokens:
+        if len(token) < MIN_TOKEN_LEN:
+            continue
+        if token in STOPWORDS:
+            continue
+        results.append(token)
+
+    return results
+
+
+def extract_keywords(text: str):
+    """
+    Kiwi 가능하면 Kiwi, 아니면 regex fallback
+    """
+    if not text:
+        return []
+
+    if kiwi is not None:
+        return extract_keywords_with_kiwi(text)
+    return extract_keywords_with_regex(text)
+
+
+# =========================================================
+# 8. 상세 JSON 구조 대응
+# =========================================================
+def normalize_details(raw_data):
+    """
+    case_details.json 구조가 list 또는 dict일 수 있으므로
+    분석 가능한 list[dict] 형태로 정규화한다.
+    """
+    if isinstance(raw_data, list):
+        return raw_data
+
+    if isinstance(raw_data, dict):
+        # 흔한 패턴들 대응
+        if "data" in raw_data and isinstance(raw_data["data"], list):
+            return raw_data["data"]
+        if "results" in raw_data and isinstance(raw_data["results"], list):
+            return raw_data["results"]
+        if "items" in raw_data and isinstance(raw_data["items"], list):
+            return raw_data["items"]
+
+        # dict 한 개만 들어있는 경우
+        return [raw_data]
+
+    return []
+
+
+# =========================================================
+# 9. 분석 대상 텍스트 조합
+# =========================================================
+def build_analysis_text(row: dict) -> str:
+    """
+    판례에서 키워드 추출 대상으로 사용할 텍스트를 합친다.
+    우선순위:
+    - 판시사항
+    - 판결요지
+    - 참조조문
+    - 사건명
+    """
+    fields = [
+        row.get("판시사항", ""),
+        row.get("판결요지", ""),
+        row.get("참조조문", ""),
+        row.get("사건명", ""),
+    ]
+
+    return " ".join([str(x) for x in fields if x])
+
+
+# =========================================================
+# 10. 빈도 분석
+# =========================================================
+def analyze_keyword_frequency(details):
+    """
+    TF(전체 빈도), DF(문서 빈도), TF-IDF 참고값 계산
+    """
+    tf_counter = Counter()
+    df_counter = Counter()
+
+    total_docs = len(details)
+
+    for idx, row in enumerate(details, start=1):
+        if idx % 100 == 0:
+            print(f"[INFO] 분석 진행: {idx}/{total_docs}")
+
+        text = build_analysis_text(row)
+        tokens = extract_keywords(text)
+
+        tf_counter.update(tokens)
+        df_counter.update(set(tokens))
+
+    rows = []
+    for token, tf in tf_counter.most_common():
+        df = df_counter[token]
+        df_ratio = round((df / total_docs) * 100, 2) if total_docs else 0.0
+        idf = math.log((total_docs + 1) / (df + 1)) + 1
+        tfidf = round(tf * idf, 4)
+
+        rows.append({
+            "키워드": token,
+            "TF_전체빈도": tf,
+            "DF_문서빈도": df,
+            "DF비율(%)": df_ratio,
+            "TFIDF_참고값": tfidf
+        })
+
+    result_df = pd.DataFrame(rows)
+    return result_df
+
+
+# =========================================================
+# 11. 추천 키워드 추출
+# =========================================================
+def make_recommended_keywords(result_df: pd.DataFrame):
+    """
+    TF / DF / TF-IDF 결과를 기반으로 추천 키워드를 추출한다.
+    가중치 없이, 조건 필터 후 TF-IDF 기준으로 정렬한다.
+    """
+    if result_df.empty:
+        return pd.DataFrame()
+
+    recommend_df = result_df.copy()
+
+    # 조건 필터
+    recommend_df = recommend_df[
+        (recommend_df["키워드"].str.len() >= RECOMMEND_MIN_LEN) &
+        (recommend_df["TF_전체빈도"] >= RECOMMEND_MIN_TF) &
+        (recommend_df["DF비율(%)"] >= RECOMMEND_MIN_DF_RATIO) &
+        (recommend_df["DF비율(%)"] <= RECOMMEND_MAX_DF_RATIO) &
+        (~recommend_df["키워드"].isin(GENERIC_EXCLUDE))
+    ].copy()
+
+    # 정렬: TF-IDF 우선, 같으면 DF / TF 기준
+    recommend_df = recommend_df.sort_values(
+        by=["TFIDF_참고값", "DF_문서빈도", "TF_전체빈도"],
+        ascending=[False, False, False]
+    ).reset_index(drop=True)
+
+    # 상위 N개만 사용
+    recommend_df = recommend_df.head(RECOMMEND_TOP_N).copy()
+
+    return recommend_df
+
+
+def print_recommended_keywords(recommend_df: pd.DataFrame, top_n=50):
+    """
+    추천 키워드를 콘솔에 출력한다.
+    """
+    if recommend_df.empty:
+        print("\n[추천 키워드] 조건에 맞는 키워드가 없습니다.")
+        return
+
+    print(f"\n[추천 키워드 상위 {min(top_n, len(recommend_df))}개]")
+    print(recommend_df.head(top_n).to_string(index=False))
+
+    recommended_list = recommend_df["키워드"].head(top_n).tolist()
+    print("\n[Python 리스트용 추천 키워드]")
+    print("FILTER_KEYWORDS =", recommended_list)
+
+
+# =========================================================
+# 12. 실행
+# =========================================================
+def main():
+    raw_details = load_json(CASE_DETAILS_PATH)
+    details = normalize_details(raw_details)
+
+    print(f"[INFO] 상세 판례 수: {len(details)}")
+
+    if not details:
+        print("[ERROR] 분석할 상세 데이터가 없습니다.")
+        return
+
+    result_df = analyze_keyword_frequency(details)
+
+    if result_df.empty:
+        print("[ERROR] 키워드가 추출되지 않았습니다.")
+        return
+
+    # TF 기준 저장
+    result_df.to_csv(TF_OUTPUT_PATH, index=False, encoding="utf-8-sig")
+
+    # DF 기준 정렬 저장
+    df_sorted = result_df.sort_values(
+        by=["DF_문서빈도", "TF_전체빈도"],
+        ascending=[False, False]
+    ).reset_index(drop=True)
+    df_sorted.to_csv(DF_OUTPUT_PATH, index=False, encoding="utf-8-sig")
+
+    # 추천 키워드 저장
+    recommend_df = make_recommended_keywords(result_df)
+    recommend_df.to_csv(RECOMMEND_OUTPUT_PATH, index=False, encoding="utf-8-sig")
+
+    print(f"[INFO] 저장 완료: {TF_OUTPUT_PATH}")
+    print(f"[INFO] 저장 완료: {DF_OUTPUT_PATH}")
+    print(f"[INFO] 저장 완료: {RECOMMEND_OUTPUT_PATH}")
+
+    print("\n[TF 상위 50개]")
+    print(result_df.head(50).to_string(index=False))
+
+    print("\n[DF 상위 50개]")
+    print(df_sorted.head(50).to_string(index=False))
+
+    print_recommended_keywords(recommend_df, top_n=50)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📝 변경 사항
- law.go.kr DRF API 기반 주택임대차 판례 수집 스크립트 추가 (case_law.py)
- TF-IDF 키워드 빈도 분석 스크립트 추가 (keyword_frequency.py)
- output/, keyword_analysis_output/ .gitignore에 추가

## 🔗 관련 이슈
closes #23

## 📸 스크린샷 (선택)
해당 없음

## 🧪 테스트
- 해당 없음 (데이터 수집 배치 스크립트)

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 추가/수정했습니다.
- [ ] 문서를 업데이트했습니다 .

## 💬 리뷰어에게
- LAW_API_KEY 환경변수 로드 방식이 프로젝트 컨벤션에 맞는지 확인 부탁드립니다.
- 출력 경로 (_BASE 기준 상대경로) 구조 적절한지 검토 부탁드립니다.