### PR TITLE
[Feature] 로톡 QA DB 전처리 기능 구현 (#25)

### DIFF
--- a/data/processors/lawtalk_qa_processor.py
+++ b/data/processors/lawtalk_qa_processor.py
@@ -40,6 +40,61 @@ class ExtractedClausesResult(BaseModel):
     )
 
 
+class LawtalkAnswerAnalysis(BaseModel):
+    """DB 적재용 answers 확장 필드 추출 결과."""
+
+    dispute_background: str = Field(
+        description=(
+            "질문 본문에서 추출한 분쟁 배경입니다. 당사자 관계, 계약 내용, "
+            "문제 발생 경위를 중심으로 3~5문장으로 작성합니다."
+        )
+    )
+    lawyer_conclusion: str = Field(
+        description=(
+            "변호사 답변의 최종 결론입니다. 유효, 무효, 일부무효 등 "
+            "법적 판단을 중심으로 1~2문장으로 작성합니다."
+        )
+    )
+    lawyer_reasoning: str = Field(
+        description=(
+            "변호사 답변의 법리 근거입니다. 답변에 명시된 내용만 "
+            "개조식 3~5줄로 작성하고, 추론은 '(추론)'으로 표시합니다."
+        )
+    )
+    action_checklist: str = Field(
+        description=(
+            "변호사 답변에서 질문자가 취해야 할 행동 또는 주의사항입니다. "
+            "답변 본문에 명시된 내용만 항목별로 작성합니다."
+        )
+    )
+
+
+LAWTALK_DB_ANALYSIS_SYSTEM_PROMPT = """당신은 한국 임대차 법률 상담 분석 전문가입니다.
+주어진 법률 상담 QA를 읽고 DB 스키마에 필요한 필드만 정확히 추출하세요.
+
+---
+
+[필드별 추출 지침]
+
+dispute_background
+- 질문 본문에서 분쟁 배경을 3~5문장으로 압축
+- 당사자 관계, 계약 내용, 문제 발생 경위 중심으로 서술
+
+lawyer_conclusion
+- 변호사 답변의 최종 결론을 1~2문장으로 서술
+- 유효/무효/일부무효 등 법적 판단을 중심으로 명확하게 서술
+
+lawyer_reasoning
+- 변호사 답변의 법리 근거를 개조식 3~5줄로 정리
+- 답변에 명시된 내용은 팩트로, 답변에서 추론된 내용은 "(추론)"으로 표시
+- 새로운 해석이나 추가 설명 금지
+
+action_checklist
+- 변호사 답변에서 질문자가 취해야 할 행동이나 주의해야 할 사항을 항목별로 추출
+- 답변 본문에 명시된 내용만 작성
+"""
+
+
 def add_unique(items, value):
     """리스트에 같은 값이 없을 때만 값을 추가한다."""
     if value not in items:
@@ -226,6 +281,80 @@ def extract_clauses_from_special_clauses_with_llm(special_clauses):
     return result.extracted_clauses
 
 
+def build_answer_analysis_prompt(question_record, answer_item):
+    """DB 적재용 답변 분석 프롬프트를 만든다."""
+    return "\n".join(
+        [
+            "다음 법률 상담 QA를 DB 스키마 필드에 맞게 분석하세요.",
+            "출력 필드는 dispute_background, lawyer_conclusion, "
+            "lawyer_reasoning, action_checklist 네 개만 사용합니다.",
+            "",
+            "[질문 제목]",
+            str(question_record.get("question_title", "")),
+            "",
+            "[질문 본문]",
+            str(question_record.get("question_body", "")),
+            "",
+            "[변호사 이름]",
+            str(answer_item.get("lawyer", "")),
+            "",
+            "[변호사 답변]",
+            str(answer_item.get("answer", "")),
+        ]
+    )
+
+
+def analyze_answer_for_db_with_llm(question_record, answer_item):
+    """질문과 답변 하나를 LLM으로 분석해 DB 적재용 확장 필드를 만든다."""
+    from shared.llm.gemini_client import gemini_client
+
+    prompt = build_answer_analysis_prompt(question_record, answer_item)
+    return gemini_client.generate(
+        prompt,
+        system_instruction=LAWTALK_DB_ANALYSIS_SYSTEM_PROMPT,
+        response_schema=LawtalkAnswerAnalysis,
+    )
+
+
+def build_question_row(record):
+    """원본 질문 레코드를 questions 테이블 형태로 바꾼다."""
+    return {
+        "id": record.get("index"),
+        "title": record.get("question_title"),
+        "body": record.get("question_body"),
+        "tags": record.get("tags", []),
+        "written_at": record.get("question_written_at_raw"),
+        "embedding": None,
+    }
+
+
+def build_answer_row(answer_id, question_id, answer_item, analysis):
+    """원본 답변과 LLM 분석 결과를 answers 테이블 형태로 바꾼다."""
+    return {
+        "id": answer_id,
+        "question_id": question_id,
+        "lawyer_name": answer_item.get("lawyer"),
+        "answer_body": dict(answer_item),
+        "written_at": answer_item.get("written_at_raw"),
+        "dispute_background": analysis.dispute_background,
+        "lawyer_conclusion": analysis.lawyer_conclusion,
+        "lawyer_reasoning": analysis.lawyer_reasoning,
+        "action_checklist": analysis.action_checklist,
+    }
+
+
+def iter_answer_items(records):
+    """원본 질문 목록에서 답변을 안정적인 순서와 ID로 순회한다."""
+    answer_id = 1
+
+    for record in records:
+        question_id = record.get("index")
+
+        for answer_item in record.get("all_answers", []):
+            yield answer_id, question_id, record, answer_item
+            answer_id = answer_id + 1
+
+
 def process_record(record):
     """로톡 QA 레코드 하나를 필터링하고 출력 형식으로 바꾼다."""
     question_body = record.get("question_body", "")
@@ -383,6 +512,111 @@ def process_rule_based_filtered_clauses(
 
     return {
         "total_records": len(source_records),
+        "processed_count": processed_count,
+        "skipped_count": skipped_count,
+        "failed_count": failed_count,
+    }
+
+
+def prepare_db_ready_records(
+    input_file="data/raw/lawtalk_QA_Context.json",
+    output_file=None,
+    answer_analyzer=None,
+    debug=False,
+    limit=None,
+):
+    """로톡 QA 원본을 questions/answers DB 적재용 JSON으로 전처리한다."""
+    input_path = Path(input_file)
+    output_path = Path(
+        output_file or "data/lawtalk_qa_preprocessed/lawtalk_qa_db_ready.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    analyzer = answer_analyzer or analyze_answer_for_db_with_llm
+    source_records = read_records_from_file(input_path)
+    question_rows = [build_question_row(record) for record in source_records]
+    answer_items = list(iter_answer_items(source_records))
+
+    if output_path.exists():
+        output_records = read_records_from_file(output_path)
+        processed_answers = output_records.get("answers", [])
+    else:
+        processed_answers = []
+
+    processed_answer_ids = {answer.get("id") for answer in processed_answers}
+    output_records = {
+        "questions": question_rows,
+        "answers": processed_answers,
+    }
+
+    processed_count = 0
+    skipped_count = 0
+    failed_count = 0
+
+    write_json(output_path, output_records)
+    debug_log(
+        debug,
+        (
+            f"db_prepare_start input_file={input_path} "
+            f"output_file={output_path} limit={limit}"
+        ),
+    )
+
+    for answer_id, question_id, question_record, answer_item in answer_items:
+        if answer_id in processed_answer_ids:
+            skipped_count = skipped_count + 1
+            debug_log(
+                debug,
+                f"db_prepare_skip answer_id={answer_id} reason=already_processed",
+            )
+            continue
+
+        if limit is not None and processed_count >= limit:
+            debug_log(debug, f"db_prepare_limit_reached limit={limit}")
+            break
+
+        debug_log(
+            debug,
+            (
+                f"db_prepare_start_answer answer_id={answer_id} "
+                f"question_id={question_id}"
+            ),
+        )
+
+        try:
+            analysis = analyzer(question_record, answer_item)
+            answer_row = build_answer_row(
+                answer_id,
+                question_id,
+                answer_item,
+                analysis,
+            )
+            output_records["answers"].append(answer_row)
+            processed_answer_ids.add(answer_id)
+        except Exception as exc:
+            failed_count = failed_count + 1
+            debug_log(
+                debug,
+                (
+                    f"db_prepare_failed answer_id={answer_id} "
+                    f"question_id={question_id} error={exc}"
+                ),
+            )
+
+        processed_count = processed_count + 1
+        write_json(output_path, output_records)
+        debug_log(
+            debug,
+            (
+                f"db_prepare_done_answer answer_id={answer_id} "
+                f"question_id={question_id}"
+            ),
+        )
+
+    debug_log(debug, "db_prepare_done")
+
+    return {
+        "total_questions": len(question_rows),
+        "total_answers": len(answer_items),
         "processed_count": processed_count,
         "skipped_count": skipped_count,
         "failed_count": failed_count,

--- a/scripts/run_processor.py
+++ b/scripts/run_processor.py
@@ -12,12 +12,14 @@ sys.path.insert(0, PROJECT_ROOT)
 def run_lawtalk_qa(args):
     """로톡 QA 전처리를 실행한다."""
     from data.processors.lawtalk_qa_processor import (
+        prepare_db_ready_records,
         process_rule_based_filtered_clauses,
         run,
     )
 
     debug = False
     extract_clauses = False
+    prepare_db = False
     limit = None
     path_args = []
 
@@ -27,6 +29,11 @@ def run_lawtalk_qa(args):
 
         if arg == "--extract-clauses":
             extract_clauses = True
+            index = index + 1
+            continue
+
+        if arg == "--prepare-db":
+            prepare_db = True
             index = index + 1
             continue
 
@@ -80,6 +87,43 @@ def run_lawtalk_qa(args):
 
         print("\n=== 특약 후처리 결과 요약 ===")
         print(f"전체 레코드: {stats['total_records']}건")
+        print(f"이번 실행 처리: {stats['processed_count']}건")
+        print(f"기존 처리 건너뜀: {stats['skipped_count']}건")
+        print(f"실패: {stats['failed_count']}건")
+        return
+
+    if prepare_db:
+        input_file = "data/raw/lawtalk_QA_Context.json"
+        output_file = None
+
+        if len(path_args) >= 1:
+            input_file = path_args[0]
+
+        if len(path_args) >= 2:
+            output_file = path_args[1]
+
+        print(f"[lawtalk_qa] DB 전처리 입력: {input_file}")
+        print(
+            "[lawtalk_qa] DB 전처리 출력: "
+            + (
+                output_file
+                or "data/lawtalk_qa_preprocessed/lawtalk_qa_db_ready.json"
+            )
+        )
+        print(f"[lawtalk_qa] 디버그: {'사용' if debug else '미사용'}")
+        if limit is not None:
+            print(f"[lawtalk_qa] 처리 제한: {limit}건")
+
+        stats = prepare_db_ready_records(
+            input_file,
+            output_file=output_file,
+            debug=debug,
+            limit=limit,
+        )
+
+        print("\n=== DB 전처리 결과 요약 ===")
+        print(f"전체 질문: {stats['total_questions']}건")
+        print(f"전체 답변: {stats['total_answers']}건")
         print(f"이번 실행 처리: {stats['processed_count']}건")
         print(f"기존 처리 건너뜀: {stats['skipped_count']}건")
         print(f"실패: {stats['failed_count']}건")

--- a/tests/test_lawtalk_qa_processor.py
+++ b/tests/test_lawtalk_qa_processor.py
@@ -5,6 +5,9 @@ from unittest.mock import Mock, patch
 import scripts.run_processor as run_processor
 from data.processors.lawtalk_qa_processor import (
     ExtractedClausesResult,
+    LawtalkAnswerAnalysis,
+    analyze_answer_for_db_with_llm,
+    build_answer_analysis_prompt,
     build_clause_postprocess_prompt,
     extract_clauses_from_special_clauses_with_llm,
     extract_law_references,
@@ -12,6 +15,7 @@ from data.processors.lawtalk_qa_processor import (
     extract_special_clauses,
     load_rule_based_filtered_records,
     process_record,
+    prepare_db_ready_records,
     process_rule_based_filtered_clauses,
     run,
 )
@@ -80,6 +84,256 @@ def test_extract_clauses_from_special_clauses_with_llm_uses_gemini_schema():
     assert kwargs["response_schema"] is ExtractedClausesResult
     assert "special_clauses" in args[0]
     assert "원상복구는 임차인이 부담" in args[0]
+
+
+def test_build_answer_analysis_prompt_uses_only_db_schema_fields():
+    question_record = {
+        "index": 1,
+        "question_title": "임대차 분쟁",
+        "question_body": "임대인이 보증금을 돌려주지 않습니다.",
+    }
+    answer_item = {
+        "lawyer": "홍길동 변호사",
+        "answer": "보증금 반환 청구를 검토해야 합니다.",
+    }
+
+    prompt = build_answer_analysis_prompt(question_record, answer_item)
+
+    assert "dispute_background" in prompt
+    assert "lawyer_conclusion" in prompt
+    assert "lawyer_reasoning" in prompt
+    assert "action_checklist" in prompt
+    assert "questioner_questions" not in prompt
+    assert "special_clauses" not in prompt
+    assert "legal_references" not in prompt
+    assert "임대인이 보증금을 돌려주지 않습니다." in prompt
+    assert "보증금 반환 청구를 검토해야 합니다." in prompt
+
+
+def test_analyze_answer_for_db_with_llm_uses_gemini_schema():
+    question_record = {
+        "index": 1,
+        "question_title": "임대차 분쟁",
+        "question_body": "임대인이 보증금을 돌려주지 않습니다.",
+    }
+    answer_item = {
+        "lawyer": "홍길동 변호사",
+        "answer": "보증금 반환 청구를 검토해야 합니다.",
+    }
+    parsed = LawtalkAnswerAnalysis(
+        dispute_background="임차인이 보증금 반환 문제를 겪고 있습니다.",
+        lawyer_conclusion="보증금 반환 청구를 검토할 수 있습니다.",
+        lawyer_reasoning="- 임대차 종료 후 반환 의무가 문제됩니다.",
+        action_checklist="- 계약서와 반환 요청 증거를 정리합니다.",
+    )
+    mock_gemini_client = Mock()
+    mock_gemini_client.generate.return_value = parsed
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "shared.llm.gemini_client": SimpleNamespace(
+                gemini_client=mock_gemini_client
+            )
+        },
+    ):
+        result = analyze_answer_for_db_with_llm(question_record, answer_item)
+
+    assert result == parsed
+    args, kwargs = mock_gemini_client.generate.call_args
+    assert kwargs["response_schema"] is LawtalkAnswerAnalysis
+    assert "system_instruction" in kwargs
+    assert "임대인이 보증금을 돌려주지 않습니다." in args[0]
+
+
+def test_prepare_db_ready_records_writes_questions_and_answers_after_each_answer(
+    tmp_path,
+):
+    input_file = tmp_path / "lawtalk_QA_Context.json"
+    output_file = tmp_path / "lawtalk_qa_db_ready.json"
+    records = [
+        {
+            "index": 7,
+            "question_title": "임대차 질문",
+            "question_body": "임차인입니다. 보증금 반환이 지연됩니다.",
+            "tags": ["#임대차"],
+            "question_written_at_raw": "2026-01-01T00:00:00.000Z",
+            "all_answers": [
+                {
+                    "lawyer": "홍길동 변호사",
+                    "answer": "내용증명을 보내고 반환 청구를 검토하세요.",
+                    "written_at_raw": "2026-01-02T00:00:00.000Z",
+                    "is_ad": False,
+                },
+                {
+                    "lawyer": "김길동 변호사",
+                    "answer": "임차권등기명령도 검토할 수 있습니다.",
+                    "written_at_raw": "2년 전 작성됨",
+                    "is_ad": False,
+                },
+            ],
+        }
+    ]
+    with open(input_file, "w", encoding="utf-8") as file:
+        json.dump(records, file, ensure_ascii=False)
+
+    def fake_analyzer(question_record, answer_item):
+        if answer_item["lawyer"] == "김길동 변호사":
+            with open(output_file, "r", encoding="utf-8") as file:
+                saved = json.load(file)
+            assert len(saved["answers"]) == 1
+            assert saved["answers"][0]["lawyer_name"] == "홍길동 변호사"
+        return LawtalkAnswerAnalysis(
+            dispute_background="임차인이 보증금 반환 지연을 겪고 있습니다.",
+            lawyer_conclusion="반환 청구를 검토할 수 있습니다.",
+            lawyer_reasoning="- 임대차 종료 후 반환 의무가 문제됩니다.",
+            action_checklist="- 증거를 정리합니다.",
+        )
+
+    stats = prepare_db_ready_records(
+        input_file,
+        output_file=output_file,
+        answer_analyzer=fake_analyzer,
+    )
+
+    with open(output_file, "r", encoding="utf-8") as file:
+        processed = json.load(file)
+
+    assert stats == {
+        "total_questions": 1,
+        "total_answers": 2,
+        "processed_count": 2,
+        "skipped_count": 0,
+        "failed_count": 0,
+    }
+    assert processed["questions"] == [
+        {
+            "id": 7,
+            "title": "임대차 질문",
+            "body": "임차인입니다. 보증금 반환이 지연됩니다.",
+            "tags": ["#임대차"],
+            "written_at": "2026-01-01T00:00:00.000Z",
+            "embedding": None,
+        }
+    ]
+    assert processed["answers"][0]["id"] == 1
+    assert processed["answers"][0]["question_id"] == 7
+    assert processed["answers"][0]["answer_body"] == records[0]["all_answers"][0]
+    assert processed["answers"][1]["written_at"] == "2년 전 작성됨"
+
+
+def test_prepare_db_ready_records_skips_existing_answers_and_respects_limit(tmp_path):
+    input_file = tmp_path / "lawtalk_QA_Context.json"
+    output_file = tmp_path / "lawtalk_qa_db_ready.json"
+    records = [
+        {
+            "index": 3,
+            "question_title": "질문",
+            "question_body": "본문",
+            "tags": [],
+            "question_written_at_raw": "작성일 텍스트",
+            "all_answers": [
+                {"lawyer": "A", "answer": "답변 A", "written_at_raw": "A일"},
+                {"lawyer": "B", "answer": "답변 B", "written_at_raw": "B일"},
+                {"lawyer": "C", "answer": "답변 C", "written_at_raw": "C일"},
+            ],
+        }
+    ]
+    with open(input_file, "w", encoding="utf-8") as file:
+        json.dump(records, file, ensure_ascii=False)
+    with open(output_file, "w", encoding="utf-8") as file:
+        json.dump(
+            {
+                "questions": [],
+                "answers": [
+                    {
+                        "id": 1,
+                        "question_id": 3,
+                        "lawyer_name": "A",
+                        "answer_body": records[0]["all_answers"][0],
+                        "written_at": "A일",
+                        "dispute_background": "기존",
+                        "lawyer_conclusion": "기존",
+                        "lawyer_reasoning": "기존",
+                        "action_checklist": "기존",
+                    }
+                ],
+            },
+            file,
+            ensure_ascii=False,
+        )
+
+    calls = []
+
+    def fake_analyzer(question_record, answer_item):
+        calls.append(answer_item["lawyer"])
+        return LawtalkAnswerAnalysis(
+            dispute_background="배경",
+            lawyer_conclusion="결론",
+            lawyer_reasoning="근거",
+            action_checklist="행동",
+        )
+
+    stats = prepare_db_ready_records(
+        input_file,
+        output_file=output_file,
+        answer_analyzer=fake_analyzer,
+        limit=1,
+    )
+
+    with open(output_file, "r", encoding="utf-8") as file:
+        processed = json.load(file)
+
+    assert calls == ["B"]
+    assert stats["processed_count"] == 1
+    assert stats["skipped_count"] == 1
+    assert [answer["id"] for answer in processed["answers"]] == [1, 2]
+
+
+def test_prepare_db_ready_records_uses_default_output_when_output_file_is_none(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    input_dir = tmp_path / "data" / "raw"
+    input_dir.mkdir(parents=True)
+    input_file = input_dir / "lawtalk_QA_Context.json"
+    with open(input_file, "w", encoding="utf-8") as file:
+        json.dump(
+            [
+                {
+                    "index": 1,
+                    "question_title": "질문",
+                    "question_body": "본문",
+                    "tags": [],
+                    "question_written_at_raw": "작성일",
+                    "all_answers": [
+                        {
+                            "lawyer": "A",
+                            "answer": "답변",
+                            "written_at_raw": "답변일",
+                        }
+                    ],
+                }
+            ],
+            file,
+            ensure_ascii=False,
+        )
+
+    stats = prepare_db_ready_records(
+        input_file,
+        output_file=None,
+        answer_analyzer=lambda question_record, answer_item: LawtalkAnswerAnalysis(
+            dispute_background="배경",
+            lawyer_conclusion="결론",
+            lawyer_reasoning="근거",
+            action_checklist="행동",
+        ),
+    )
+
+    output_file = tmp_path / "data" / "lawtalk_qa_preprocessed" / "lawtalk_qa_db_ready.json"
+    assert stats["processed_count"] == 1
+    assert output_file.exists()
 
 
 def test_load_rule_based_filtered_records_merges_three_files_with_source_metadata(
@@ -454,5 +708,44 @@ def test_run_lawtalk_qa_extract_clauses_option(monkeypatch):
             "data/lawtalk_qa_filtered/qa_clauses_processed.json",
             True,
             2,
+        )
+    ]
+
+
+def test_run_lawtalk_qa_prepare_db_option(monkeypatch):
+    calls = []
+
+    def fake_prepare(input_file, output_file=None, debug=False, limit=None):
+        calls.append((input_file, output_file, debug, limit))
+        return {
+            "total_questions": 5,
+            "total_answers": 10,
+            "processed_count": 3,
+            "skipped_count": 1,
+            "failed_count": 0,
+        }
+
+    monkeypatch.setattr(
+        "data.processors.lawtalk_qa_processor.prepare_db_ready_records",
+        fake_prepare,
+    )
+
+    run_processor.run_lawtalk_qa(
+        [
+            "--prepare-db",
+            "data/raw/lawtalk_QA_Context.json",
+            "data/lawtalk_qa_preprocessed/lawtalk_qa_db_ready.json",
+            "--debug",
+            "--limit",
+            "3",
+        ]
+    )
+
+    assert calls == [
+        (
+            "data/raw/lawtalk_QA_Context.json",
+            "data/lawtalk_qa_preprocessed/lawtalk_qa_db_ready.json",
+            True,
+            3,
         )
     ]


### PR DESCRIPTION
로톡 QA 원본 데이터를 questions와 answers 형태로 분리해 저장할 수 있도록 전처리 흐름을 추가합니다.

답변별 LLM 분석 필드를 생성하고 중간 저장과 재실행 건너뛰기를 지원해 긴 처리 작업을 이어서 실행할 수 있게 합니다.

Refs: #25

## 📝 변경 사항
- 로톡 QA 원본 데이터를 `questions`, `answers` 형태로 변환하는 전처리 기능을 추가했습니다.
- `data/raw/lawtalk_QA_Context.json`을 입력으로 사용하도록 구성했습니다.
- 답변별로 LLM을 사용해 아래 필드를 생성하도록 했습니다.
  - `dispute_background`
  - `lawyer_conclusion`
  - `lawyer_reasoning`
  - `action_checklist`
- 전처리 결과를 `data/lawtalk_qa_preprocessed/lawtalk_qa_db_ready.json`에 저장하도록 했습니다.
- 중간에 작업이 끊겨도 이어서 실행할 수 있도록 이미 처리된 답변은 건너뛰게 했습니다.
- `scripts/run_processor.py`에 `--prepare-db` 옵션을 추가했습니다.

## 🔗 관련 이슈
closes #25 

## 📸 스크린샷 (선택)
| Before | After |
|--------|-------|
|        |       |

## 🧪 테스트
- `python -m pytest tests/test_lawtalk_qa_processor.py -q`
- 결과: `24 passed`

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 추가/수정했습니다 (해당되는 경우).
- [x] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
- `shared/llm`을 사용해 답변 분석 필드를 생성하는 흐름이 적절한지 확인 부탁드립니다.
- 전처리 결과 JSON 구조가 이후 DB 적재 단계에서 사용하기 좋은 형태인지 봐주시면 좋겠습니다.
- 현재는 임베딩 생성이나 DB insert는 포함하지 않았고, 전처리 결과 생성까지만 담당합니다