### PR TITLE
[Feature] 계약서 업로드 및 Query Expansion API 구현 (#45)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+"""Cloud Run FastAPI application package."""
+

--- a/app/dockerfile
+++ b/app/dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY app/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY pipeline ./pipeline
+COPY shared ./shared
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, File, HTTPException, UploadFile, status
+
+from app.schemas import (
+    ContractAnalysisResponse,
+    HealthResponse,
+    SpecialTermExpansionResult,
+)
+from pipeline.preprocessing.schema import LeaseContract
+from pipeline.retrieval.query_expansion.query_expansion_schema import ClauseQueryExpansion
+
+app = FastAPI(title="ADE Contract Analysis API")
+
+
+@app.get("/health", response_model=HealthResponse)
+@app.get("/healthz", response_model=HealthResponse)
+def healthz() -> HealthResponse:
+    return HealthResponse(status="ok")
+
+
+@app.post("/v1/contracts/parse", response_model=LeaseContract)
+async def parse_contract(file: UploadFile = File(...)) -> LeaseContract:
+    pdf_bytes = await _read_pdf(file)
+    try:
+        return _parse_contract_from_pdf(pdf_bytes)
+    except Exception as error:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"계약서 전처리에 실패했습니다: {error}",
+        ) from error
+
+
+@app.post("/v1/contracts/analyze", response_model=ContractAnalysisResponse)
+async def analyze_contract(file: UploadFile = File(...)) -> ContractAnalysisResponse:
+    pdf_bytes = await _read_pdf(file)
+
+    try:
+        contract = _parse_contract_from_pdf(pdf_bytes)
+    except Exception as error:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"계약서 전처리에 실패했습니다: {error}",
+        ) from error
+
+    results: list[SpecialTermExpansionResult] = []
+    for index, special_term in enumerate(contract.special_terms):
+        clean_term = special_term.strip()
+        if not clean_term:
+            continue
+
+        try:
+            expansion = _expand_special_term(clean_term)
+            retrieval_payload = _build_retrieval_payload(expansion)
+        except Exception as error:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"query expansion에 실패했습니다: {error}",
+            ) from error
+
+        results.append(
+            SpecialTermExpansionResult(
+                index=index,
+                special_term=clean_term,
+                expansion=expansion,
+                retrieval_payload=retrieval_payload,
+            )
+        )
+
+    return ContractAnalysisResponse(
+        contract=contract,
+        special_term_expansions=results,
+    )
+
+
+async def _read_pdf(file: UploadFile) -> bytes:
+    if file.content_type not in {None, "", "application/pdf"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="PDF 파일만 업로드할 수 있습니다.",
+        )
+
+    pdf_bytes = await file.read()
+    if not pdf_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="업로드된 PDF 파일이 비어 있습니다.",
+        )
+    return pdf_bytes
+
+
+def _parse_contract_from_pdf(pdf_bytes: bytes) -> LeaseContract:
+    from pipeline.preprocessing.pipeline import parse_lease_contract_bytes
+
+    return parse_lease_contract_bytes(pdf_bytes)
+
+
+def _expand_special_term(special_term: str) -> ClauseQueryExpansion:
+    from pipeline.retrieval.query_expansion.query_expansion import expand_clause
+
+    return expand_clause(special_term)
+
+
+def _build_retrieval_payload(expansion: ClauseQueryExpansion) -> dict:
+    from pipeline.retrieval.query_expansion.retrieval_adapter import build_retrieval_payload
+
+    return build_retrieval_payload(expansion)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,7 @@
+pydantic>=2.0
+pydantic-settings>=2.0
+fastapi
+uvicorn[standard]
+python-multipart
+google-genai>=1.0
+google-cloud-documentai>=2.0

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from pipeline.preprocessing.schema import LeaseContract
+from pipeline.retrieval.query_expansion.query_expansion_schema import ClauseQueryExpansion
+
+
+class HealthResponse(BaseModel):
+    status: str
+
+
+class SpecialTermExpansionResult(BaseModel):
+    index: int
+    special_term: str
+    expansion: ClauseQueryExpansion
+    retrieval_payload: dict[str, Any]
+
+
+class ContractAnalysisResponse(BaseModel):
+    contract: LeaseContract
+    special_term_expansions: list[SpecialTermExpansionResult]
+

--- a/pipeline/preprocessing/__init__.py
+++ b/pipeline/preprocessing/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "PreprocessingError",
     "contract_to_json",
     "parse_lease_contract",
+    "parse_lease_contract_bytes",
     "parse_lease_contract_from_text",
 ]
 
@@ -15,6 +16,7 @@ def __getattr__(name: str):
         "PreprocessingError",
         "contract_to_json",
         "parse_lease_contract",
+        "parse_lease_contract_bytes",
         "parse_lease_contract_from_text",
     }:
         from pipeline.preprocessing import pipeline

--- a/pipeline/preprocessing/pipeline.py
+++ b/pipeline/preprocessing/pipeline.py
@@ -64,6 +64,14 @@ def _save_to_gcs(contract: LeaseContract, prefix: str, stem: str) -> str:
     return blob_name
 
 
+def _parse_contract_bytes(pdf_bytes: bytes) -> LeaseContract:
+    try:
+        layout_text = layout.extract_layout_text(pdf_bytes)
+        return parse_contract_text(mask_pii(layout_text))
+    except (layout.LayoutError, RuleParseError) as error:
+        raise PreprocessingError(str(error)) from error
+
+
 # ---------------------------------------------------------------------------
 # 공개 API
 # ---------------------------------------------------------------------------
@@ -98,16 +106,25 @@ def parse_lease_contract(
     del client
     pdf_bytes, stem = _load_pdf(pdf_uri)
 
-    try:
-        layout_text = layout.extract_layout_text(pdf_bytes)
-        contract = parse_contract_text(mask_pii(layout_text))
-    except (layout.LayoutError, RuleParseError) as error:
-        raise PreprocessingError(str(error)) from error
+    contract = _parse_contract_bytes(pdf_bytes)
 
     if output_gcs_prefix is not None:
         _save_to_gcs(contract, output_gcs_prefix, stem)
 
     return contract
+
+
+def parse_lease_contract_bytes(
+    pdf_bytes: bytes,
+    *,
+    client: object | None = None,
+) -> LeaseContract:
+    """PDF bytes를 ``LeaseContract``로 파싱한다.
+
+    FastAPI 파일 업로드처럼 이미 메모리에 올라온 PDF를 처리할 때 사용한다.
+    """
+    del client
+    return _parse_contract_bytes(pdf_bytes)
 
 
 def parse_lease_contract_from_text(

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REGION="us-central1"
+SERVICE_NAME="ade-contract-api"
+REPOSITORY="ade-api"
+IMAGE_NAME="ade-contract-api"
+ENV_FILE=".env"
+ALLOW_UNAUTHENTICATED="true"
+RUN_TESTS="true"
+TAG=""
+PROJECT_ID="${PROJECT_ID:-}"
+
+usage() {
+  cat <<'EOF'
+Deploy the ADE FastAPI service to Cloud Run.
+
+Usage:
+  PROJECT_ID=your-project ./scripts/deploy_cloud_run.sh [options]
+
+Options:
+  --project-id VALUE       GCP project ID. Defaults to PROJECT_ID env or GCP_PROJECT_ID in .env.
+  --region VALUE           GCP region. Default: us-central1.
+  --service VALUE          Cloud Run service name. Default: ade-contract-api.
+  --repo VALUE             Artifact Registry repository. Default: ade-api.
+  --image-name VALUE       Docker image name. Default: ade-contract-api.
+  --env-file VALUE         Environment file for Cloud Run. Default: .env.
+  --tag VALUE              Image tag. Default: YYYYMMDD-HHMMSS-gitsha.
+  --private                Do not allow unauthenticated access.
+  --skip-tests             Skip local pytest check before build.
+  -h, --help               Show this help.
+
+Examples:
+  PROJECT_ID=my-project ./scripts/deploy_cloud_run.sh
+  ./scripts/deploy_cloud_run.sh --project-id my-project --private
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+read_env_value() {
+  local key="$1"
+  local file="$2"
+
+  awk -F= -v key="$key" '
+    $0 !~ /^[[:space:]]*#/ && $1 == key {
+      value = substr($0, index($0, "=") + 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^"|"$/, "", value)
+      gsub(/^'\''|'\''$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-id)
+      PROJECT_ID="${2:-}"
+      shift 2
+      ;;
+    --region)
+      REGION="${2:-}"
+      shift 2
+      ;;
+    --service)
+      SERVICE_NAME="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPOSITORY="${2:-}"
+      shift 2
+      ;;
+    --image-name)
+      IMAGE_NAME="${2:-}"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="${2:-}"
+      shift 2
+      ;;
+    --tag)
+      TAG="${2:-}"
+      shift 2
+      ;;
+    --private)
+      ALLOW_UNAUTHENTICATED="false"
+      shift
+      ;;
+    --skip-tests)
+      RUN_TESTS="false"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+require_command gcloud
+require_command docker
+require_command curl
+
+[[ -f "$ENV_FILE" ]] || die "Environment file not found: $ENV_FILE"
+
+if [[ -z "$PROJECT_ID" ]]; then
+  PROJECT_ID="$(read_env_value GCP_PROJECT_ID "$ENV_FILE")"
+fi
+[[ -n "$PROJECT_ID" ]] || die "PROJECT_ID is required. Pass --project-id or set GCP_PROJECT_ID in $ENV_FILE."
+
+if [[ -z "$TAG" ]]; then
+  timestamp="$(date +%Y%m%d-%H%M%S)"
+  git_sha="$(git rev-parse --short HEAD 2>/dev/null || true)"
+  if [[ -n "$git_sha" ]]; then
+    TAG="${timestamp}-${git_sha}"
+  else
+    TAG="$timestamp"
+  fi
+fi
+
+IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/${IMAGE_NAME}:${TAG}"
+
+echo "Project:  $PROJECT_ID"
+echo "Region:   $REGION"
+echo "Service:  $SERVICE_NAME"
+echo "Image:    $IMAGE"
+echo "Env file: $ENV_FILE"
+
+gcloud config set project "$PROJECT_ID" >/dev/null
+
+echo "Enabling required APIs..."
+gcloud services enable \
+  run.googleapis.com \
+  cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com \
+  documentai.googleapis.com \
+  aiplatform.googleapis.com \
+  sqladmin.googleapis.com \
+  storage.googleapis.com
+
+echo "Ensuring Artifact Registry repository exists..."
+if ! gcloud artifacts repositories describe "$REPOSITORY" --location "$REGION" >/dev/null 2>&1; then
+  gcloud artifacts repositories create "$REPOSITORY" \
+    --repository-format=docker \
+    --location="$REGION" \
+    --description="ADE API Docker images"
+fi
+
+if [[ "$RUN_TESTS" == "true" ]]; then
+  require_command pytest
+  echo "Running local API tests..."
+  pytest tests/app/test_main.py -q
+fi
+
+echo "Configuring Docker authentication..."
+gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+echo "Building Docker image..."
+docker build -f app/dockerfile -t "$IMAGE" .
+
+echo "Pushing Docker image..."
+docker push "$IMAGE"
+
+deploy_args=(
+  run deploy "$SERVICE_NAME"
+  --image "$IMAGE"
+  --region "$REGION"
+  --env-vars-file "$ENV_FILE"
+)
+
+if [[ "$ALLOW_UNAUTHENTICATED" == "true" ]]; then
+  deploy_args+=(--allow-unauthenticated)
+else
+  deploy_args+=(--no-allow-unauthenticated)
+fi
+
+echo "Deploying to Cloud Run..."
+gcloud "${deploy_args[@]}"
+
+SERVICE_URL="$(gcloud run services describe "$SERVICE_NAME" --region "$REGION" --format='value(status.url)')"
+echo "Service URL: $SERVICE_URL"
+
+echo "Checking /health..."
+if [[ "$ALLOW_UNAUTHENTICATED" == "true" ]]; then
+  curl -fsS "$SERVICE_URL/health"
+else
+  IDENTITY_TOKEN="$(gcloud auth print-identity-token)"
+  curl -fsS -H "Authorization: Bearer ${IDENTITY_TOKEN}" "$SERVICE_URL/health"
+fi
+echo

--- a/shared/llm/gemini_client.py
+++ b/shared/llm/gemini_client.py
@@ -39,6 +39,53 @@ class LLMError(RuntimeError):
     """Gemini API 호출 중 발생한 모든 오류의 단일 타입."""
 
 
+def _stringify_value(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    enum_value = getattr(value, "value", None)
+    if enum_value is not None:
+        return str(enum_value)
+
+    enum_name = getattr(value, "name", None)
+    if enum_name is not None:
+        return str(enum_name)
+
+    return str(value)
+
+
+def _summarize_empty_response(response: Any) -> str:
+    details: list[str] = []
+
+    response_id = _stringify_value(getattr(response, "response_id", None))
+    if response_id:
+        details.append(f"response_id={response_id}")
+
+    prompt_feedback = getattr(response, "prompt_feedback", None)
+    if prompt_feedback is not None:
+        block_reason = _stringify_value(getattr(prompt_feedback, "block_reason", None))
+        block_message = _stringify_value(
+            getattr(prompt_feedback, "block_reason_message", None)
+        )
+        if block_reason:
+            details.append(f"prompt_block_reason={block_reason}")
+        if block_message:
+            details.append(f"prompt_block_message={block_message}")
+
+    candidates = getattr(response, "candidates", None) or []
+    for index, candidate in enumerate(candidates):
+        finish_reason = _stringify_value(getattr(candidate, "finish_reason", None))
+        finish_message = _stringify_value(getattr(candidate, "finish_message", None))
+        if finish_reason:
+            details.append(f"candidate[{index}].finish_reason={finish_reason}")
+        if finish_message:
+            details.append(f"candidate[{index}].finish_message={finish_message}")
+
+    if not details:
+        return "no diagnostic fields present"
+    return "; ".join(details)
+
+
 class GeminiClient:
     """Vertex AI Gemini API 호출 래퍼.
 
@@ -139,7 +186,24 @@ class GeminiClient:
                 f"  (model={model or self._default_model})"
             )
 
-        return response.parsed if response_schema is not None else response.text
+        if response_schema is None:
+            if response.text is None:
+                raise LLMError(
+                    "Gemini returned empty response: "
+                    f"{_summarize_empty_response(response)}"
+                )
+            return response.text
+
+        if response.parsed is not None:
+            return response.parsed
+
+        if response.text is not None:
+            return response.text
+
+        raise LLMError(
+            "Gemini returned empty response: "
+            f"{_summarize_empty_response(response)}"
+        )
 
 
 gemini_client: GeminiClient = GeminiClient()


### PR DESCRIPTION
## 📝 변경 사항
- 사용자가 PDF 계약서를 업로드할 수 있는 FastAPI 앱을 추가했습니다.
- `/health`, `/healthz`, `/v1/contracts/parse`, `/v1/contracts/analyze` 엔드포인트를 만들었습니다.
- `/v1/contracts/analyze`에서 계약서 파싱 후 특약별 query expansion 결과와 retrieval payload를 반환하도록 연결했습니다.
- Cloud Run에서 실행할 수 있도록 Dockerfile을 추가했습니다.
- `.env` 기반으로 Cloud Run에 배포하는 스크립트를 추가했습니다.
- PDF bytes 입력을 처리할 수 있도록 `parse_lease_contract_bytes`를 추가했습니다.
- Gemini 응답이 비어 있을 때 `NoneType` 에러만 나오지 않고 원인을 더 확인할 수 있게 수정했습니다.

## 🔗 관련 이슈
closes #이슈번호

## 📸 스크린샷 (선택)
| Before | After |
|--------|-------|
| API로 직접 PDF 업로드 테스트가 어려웠습니다. | Cloud Run `/docs`에서 PDF 업로드와 분석 요청을 테스트할 수 있습니다. |

## 🧪 테스트
- 로컬 테스트를 한 번 돌려봤습니다.
- Cloud Run에 올린 뒤 `/docs`에서 PDF 업로드 요청이 되는지 확인했습니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 추가/수정했습니다 (해당되는 경우).
- [x] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
- FastAPI 응답 구조가 지금 단계에서 보기 쉬운지 확인 부탁드립니다.
- Cloud Run 배포 스크립트 옵션이 팀원이 쓰기에 충분히 단순한지 봐주시면 좋겠습니다.
- 아직 retrieval 검색까지는 연결하지 않았고, 이번 PR은 파일 업로드부터 query expansion까지 연결하는 범위입니다.
