### PR TITLE
[Refactor] bm25 검색 다중 계약서 일괄 처리 구조로 전환 (#50)

### DIFF
--- a/pipeline/retrieval/bm25_retrieval.py
+++ b/pipeline/retrieval/bm25_retrieval.py
@@ -1,17 +1,32 @@
 """
 BM25 통합 검색 파이프라인
-- 판례 매칭: bm25_keywords → case_law.csv (issue + judgment_summary) → bm25_caselaw.json
-- 법령 매칭: bm25_keywords → law_child.csv (child_text)             → bm25_law.json
+- 판례 매칭: bm25_keywords → case_law.csv (issue + judgment_summary) → bm25_caselaw/{stem}.json
+- 법령 매칭: bm25_keywords → law_child.csv (child_text)             → bm25_law/{stem}.json
+
+[입력]
+  폴더 경로: query_expansion_full/ 내 *.json 파일 자동 수집
+  단일 파일: 기존처럼 동작
+
+[출력]
+  입력 JSON 파일 1개 → 결과 JSON 파일 1개 (파일명 동일, 출력 디렉토리 하위에 저장)
+  하나의 JSON에 특약이 여러 개 담겨 있어도 해당 파일 기준으로 한 파일로 출력됨
+  예) query_expansion_full/sample_1.json → output/retrieval/bm25_law/sample_1.json
+
+[쿼리 토크나이징]
+  corpus(법령·판례)는 kiwipiepy 형태소 분석으로 토크나이징
+  query는 쿼리 익스펜션 결과 bm25_keywords를 공백 제거 후 그대로 사용
+  (형태소 재분리 시 복합명사 손실 문제 방지)
 """
 import argparse
 import json
 import pandas as pd
 from rank_bm25 import BM25Okapi
+import kiwipiepy_model
 from kiwipiepy import Kiwi
 from pathlib import Path
 
 # ─── 경로 설정 ──────────────────────────────────────────
-_BASE   = Path(__file__).resolve().parent.parent.parent
+_BASE   = Path(__file__).resolve().parent
 _DATA   = _BASE / "data"
 _OUTPUT = _BASE / "output"
 
@@ -30,23 +45,25 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--caselaw", default=str(_OUTPUT / "case_law.csv"),
-        help="판례 CSV 경로 (default: output/case_law.csv)",
+        help="판례 CSV 경로 (default: case_law.csv)",
     )
     parser.add_argument(
-        "--law", default=str(_DATA / "law_chunks" / "law_child.csv"),
-        help="법령 CSV 경로 (default: data/law_chunks/law_child.csv)",
+        "--law", default=str(_DATA / "law_child.csv"),
+        help="법령 CSV 경로 (default: law_child.csv)",
     )
     parser.add_argument(
-        "--samples", default=str(_DATA / "all_samples.json"),
-        help="샘플 JSON 경로 (default: data/all_samples.json) — query expansion 테스트 데이터이며 교체 가능",
+        "--samples",
+        default=str(_DATA / "query_expansion_full"),
+        help="샘플 JSON 경로 또는 폴더 경로 "
+             "(폴더 지정 시 *.json 전체 수집, default: query_expansion_full/)",
     )
     parser.add_argument(
-        "--out-case", default=str(_OUTPUT / "bm25_caselaw.json"),
-        help="판례 결과 저장 경로 (default: output/bm25_caselaw.json)",
+        "--out-case", default=str(_OUTPUT / "retrieval" / "bm25_caselaw"),
+        help="판례 결과 저장 디렉토리 (default: retrieval/bm25_caselaw/)",
     )
     parser.add_argument(
-        "--out-law", default=str(_OUTPUT / "bm25_law.json"),
-        help="법령 결과 저장 경로 (default: output/bm25_law.json)",
+        "--out-law", default=str(_OUTPUT / "retrieval" / "bm25_law"),
+        help="법령 결과 저장 디렉토리 (default: retrieval/bm25_law/)",
     )
     parser.add_argument(
         "--top-k-case", type=int, default=TOP_K_CASE,
@@ -59,11 +76,11 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-# ── Kiwi 초기화 ──────────────────────────────────────────
-import kiwipiepy_model
+# ── Kiwi 초기화 (corpus 토크나이징 전용) ─────────────────
 kiwi = Kiwi(model_path=str(Path(kiwipiepy_model.__file__).parent))
 
 def tokenize(text: str) -> list[str]:
+    """corpus(법령·판례 문서) 토크나이징 전용 — 형태소 분석"""
     if not text or not text.strip():
         return []
     tokens = [
@@ -74,22 +91,53 @@ def tokenize(text: str) -> list[str]:
     return tokens if tokens else text.split()
 
 def build_query_tokens(keywords: list[str]) -> list[str]:
-    return list(dict.fromkeys(
-        token for kw in keywords for token in tokenize(kw)
-    ))
+    tokens = []
+    for kw in keywords:
+        tokens.extend(tokenize(kw))        # corpus와 같은 토큰 공간
+        tokens.append(kw.replace(" ", "")) # raw 보너스
+    return list(dict.fromkeys(tokens))
 
 
-# ── 샘플 JSON 로드 ────────────────────────────────────────
-def load_samples(path: str) -> list:
-    with open(path, encoding="utf-8") as f:
-        return json.load(f)
+# ── 샘플 로드 ─────────────────────────────────────────────
+def load_samples_by_file(path: str) -> list[tuple[str, list]]:
+    """
+    입력 경로별로 (파일 stem, 샘플 리스트) 튜플 반환.
+    - 폴더: 하위 *.json 파일 각각을 독립 단위로 읽음
+    - 단일 파일: [(stem, samples)] 형태로 반환
+    파일 하나에 특약이 여러 개(리스트) 또는 하나(객체)이어도 모두 허용.
+    """
+    p = Path(path)
 
-def save_json(data: list, path: str) -> None:
-    out = Path(path)
-    out.parent.mkdir(parents=True, exist_ok=True)
-    with open(out, "w", encoding="utf-8") as f:
+    if p.is_dir():
+        files = sorted(p.glob("*.json"))
+        if not files:
+            raise FileNotFoundError(f"[ERROR] 폴더에 JSON 파일이 없습니다: {p}")
+        file_samples = []
+        for f in files:
+            with open(f, encoding="utf-8") as fh:
+                obj = json.load(fh)
+            samples = obj if isinstance(obj, list) else [obj]
+            file_samples.append((f.stem, samples))
+        total = sum(len(s) for _, s in file_samples)
+        print(f"  샘플 로드: {len(files)}개 파일, 총 {total}개 특약")
+        return file_samples
+
+    else:
+        with open(p, encoding="utf-8") as f:
+            obj = json.load(f)
+        samples = obj if isinstance(obj, list) else [obj]
+        print(f"  샘플 로드: 1개 파일, {len(samples)}개 특약")
+        return [(p.stem, samples)]
+
+
+def save_json(data: list, out_dir: str, stem: str) -> None:
+    """out_dir / stem.json 으로 저장"""
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    out_path = out / f"{stem}.json"
+    with open(out_path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
-    print(f"✅ 저장 완료: {out}")
+    print(f"  ✅ 저장: {out_path}")
 
 
 # ── 판례 BM25 매칭 ────────────────────────────────────────
@@ -114,50 +162,50 @@ def run_case_matching(args) -> None:
     bm25 = BM25Okapi(corpus_tokens)
     print("  BM25 인덱스 완료")
 
-    samples = load_samples(args.samples)
-    results = []
+    file_samples = load_samples_by_file(args.samples)
 
-    for sample in samples:
-        clause       = sample["clause"]
-        keywords     = sample["retrieval_payload"]["bm25_keywords"]
-        query_tokens = build_query_tokens(keywords)
+    for stem, samples in file_samples:
+        results = []
+        for sample in samples:
+            clause       = sample["clause"]
+            keywords     = sample["retrieval_payload"]["bm25_keywords"]
+            query_tokens = build_query_tokens(keywords)
 
-        scores  = bm25.get_scores(query_tokens)
-        top_idx = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:args.top_k_case]
+            scores  = bm25.get_scores(query_tokens)
+            top_idx = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:args.top_k_case]
 
-        matched = []
-        for rank, idx in enumerate(top_idx, 1):
-            row          = df_valid.iloc[idx]
-            issue_text   = str(row["issue"])
-            summary_text = str(row["judgment_summary"])
-            matched.append({
-                "rank":            rank,
-                "score":           round(float(scores[idx]), 4),
-                "case_id":         int(row["case_id"]),
-                "case_name":       str(row["case_name"]),
-                "case_number":     str(row["case_number"]),
-                "judgment_date":   str(row["judgment_date"]),
-                "court_name":      str(row["court_name"]),
-                "issue_preview":   issue_text[:100] + "..." if len(issue_text) > 100 else issue_text,
-                "summary_preview": summary_text[:100] + "..." if len(summary_text) > 100 else summary_text,
+            matched = []
+            for rank, idx in enumerate(top_idx, 1):
+                row          = df_valid.iloc[idx]
+                issue_text   = str(row["issue"])
+                summary_text = str(row["judgment_summary"])
+                matched.append({
+                    "rank":            rank,
+                    "score":           round(float(scores[idx]), 4),
+                    "case_id":         int(row["case_id"]),
+                    "case_name":       str(row["case_name"]),
+                    "case_number":     str(row["case_number"]),
+                    "judgment_date":   str(row["judgment_date"]),
+                    "court_name":      str(row["court_name"]),
+                    "issue_preview":   issue_text[:100] + "..." if len(issue_text) > 100 else issue_text,
+                    "summary_preview": summary_text[:100] + "..." if len(summary_text) > 100 else summary_text,
+                })
+
+            results.append({
+                "index":        sample["index"],
+                "clause":       clause,
+                "query_tokens": query_tokens,
+                "top_matches":  matched,
             })
 
-        results.append({
-            "index":        sample["index"],
-            "clause":       clause,
-            "query_tokens": query_tokens,
-            "top_matches":  matched,
-        })
+        print(f"\n[{stem}] {len(results)}개 특약 검색 완료")
+        for r in results:
+            print(f"  [{r['index']}] {r['clause'][:50]}")
+            for m in r["top_matches"][:3]:
+                print(f"    #{m['rank']} score={m['score']:6.3f}  {m['case_name']} "
+                      f"({m['court_name']}, {str(m['judgment_date'])[:8]})")
 
-    for r in results:
-        print(f"\n[{r['index']}] {r['clause']}")
-        print(f"  query tokens: {r['query_tokens']}")
-        for m in r["top_matches"]:
-            print(f"  #{m['rank']} score={m['score']:6.3f}  {m['case_name']} "
-                  f"({m['court_name']}, {str(m['judgment_date'])[:8]})")
-            print(f"         [판시] {m['issue_preview']}")
-
-    save_json(results, args.out_case)
+        save_json(results, args.out_case, stem)
 
 
 # ── 법령 BM25 매칭 ────────────────────────────────────────
@@ -172,46 +220,46 @@ def run_law_matching(args) -> None:
     bm25 = BM25Okapi(corpus_tokens)
     print("  BM25 인덱스 완료")
 
-    samples = load_samples(args.samples)
-    results = []
+    file_samples = load_samples_by_file(args.samples)
 
-    for sample in samples:
-        clause       = sample["clause"]
-        keywords     = sample["retrieval_payload"]["bm25_keywords"]
-        query_tokens = build_query_tokens(keywords)
+    for stem, samples in file_samples:
+        results = []
+        for sample in samples:
+            clause       = sample["clause"]
+            keywords     = sample["retrieval_payload"]["bm25_keywords"]
+            query_tokens = build_query_tokens(keywords)
 
-        scores  = bm25.get_scores(query_tokens)
-        top_idx = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:args.top_k_law]
+            scores  = bm25.get_scores(query_tokens)
+            top_idx = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:args.top_k_law]
 
-        matched = []
-        for rank, idx in enumerate(top_idx, 1):
-            row = df.iloc[idx]
-            matched.append({
-                "rank":         rank,
-                "score":        round(float(scores[idx]), 4),
-                "clause_key":   str(row["clause_key"]),
-                "law_name":     str(row["law_name"]),
-                "article_no":   str(row["article_no"]),
-                "paragraph_no": str(row["paragraph_no"]),
-                "child_text":   str(row["child_text"])[:120] + "...",
+            matched = []
+            for rank, idx in enumerate(top_idx, 1):
+                row = df.iloc[idx]
+                matched.append({
+                    "rank":         rank,
+                    "score":        round(float(scores[idx]), 4),
+                    "clause_key":   str(row["clause_key"]),
+                    "law_name":     str(row["law_name"]),
+                    "article_no":   str(row["article_no"]),
+                    "paragraph_no": str(row["paragraph_no"]),
+                    "child_text":   str(row["child_text"])[:120] + "...",
+                })
+
+            results.append({
+                "index":        sample["index"],
+                "clause":       clause,
+                "query_tokens": query_tokens,
+                "top_matches":  matched,
             })
 
-        results.append({
-            "index":        sample["index"],
-            "clause":       clause,
-            "query_tokens": query_tokens,
-            "top_matches":  matched,
-        })
+        print(f"\n[{stem}] {len(results)}개 특약 검색 완료")
+        for r in results:
+            print(f"  [{r['index']}] {r['clause'][:50]}")
+            for m in r["top_matches"][:3]:
+                print(f"    #{m['rank']} score={m['score']:6.3f}  "
+                      f"{m['law_name']} 제{m['article_no']}조 제{m['paragraph_no']}항")
 
-    for r in results:
-        print(f"\n[{r['index']}] {r['clause']}")
-        print(f"  query tokens: {r['query_tokens']}")
-        for m in r["top_matches"]:
-            print(f"  #{m['rank']} score={m['score']:6.3f}  "
-                  f"{m['law_name']} 제{m['article_no']}조 제{m['paragraph_no']}항")
-            print(f"         {m['child_text'][:80]}...")
-
-    save_json(results, args.out_law)
+        save_json(results, args.out_law, stem)
 
 
 # ── 진입점 ────────────────────────────────────────────────


### PR DESCRIPTION
## 📝 변경 사항
- 샘플 JSON 입력을 단일 파일에서 폴더(`query_expansion_full/`) 내 `*.json` 전체 자동 수집 또는 단일 파일 모두 허용하도록 변경
- 결과 저장을 단일 파일에서 입력 파일명 기준 디렉토리 분리 저장(`retrieval/bm25_caselaw/{stem}.json`)으로 변경
- `build_query_tokens()` 형태소 분석 토큰 + raw 토큰 병합으로 복합명사 보존
- `load_samples()` → `load_samples_by_file()` 교체
- `import kiwipiepy_model` 상단 import 블록으로 이동

## 🔗 관련 이슈
closes #50

## 📸 스크린샷 (선택)
| Before | After |
|--------|-------|
| 해당 없음 | 해당 없음 |

## 🧪 테스트
- `--target all` 옵션으로 판례·법령 검색 모두 실행 확인
- 단일 파일 입력 / 폴더 입력 각각 동작 확인
- `output/retrieval/bm25_caselaw/`, `output/retrieval/bm25_law/` 하위에 파일 정상 저장 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.

## 💬 리뷰어에게
- `_OUTPUT = _BASE / "output"` 경로 설정이 프로젝트 디렉토리 구조와 맞는지 확인 부탁드립니다.