### PR TITLE
[Refactor]  BM25 데이터 소스 CSV에서 DB로 변경 (#67)

### DIFF
--- a/pipeline/retrieval/bm25_retrieval.py
+++ b/pipeline/retrieval/bm25_retrieval.py
@@ -1,7 +1,7 @@
 """
 BM25 통합 검색 파이프라인
-- 판례 매칭: bm25_keywords → case_law.csv (issue + judgment_summary) → bm25_caselaw/{stem}.json
-- 법령 매칭: bm25_keywords → law_child.csv (child_text)             → bm25_law/{stem}.json
+- 판례 매칭: bm25_keywords → case_law (DB: issue + judgment_summary) → bm25_caselaw/{stem}.json
+- 법령 매칭: bm25_keywords → law_child (DB: child_text)              → bm25_law/{stem}.json
 
 [입력]
   폴더 경로: query_expansion_full/ 내 *.json 파일 자동 수집
@@ -10,46 +10,56 @@ BM25 통합 검색 파이프라인
 [출력]
   입력 JSON 파일 1개 → 결과 JSON 파일 1개 (파일명 동일, 출력 디렉토리 하위에 저장)
   하나의 JSON에 특약이 여러 개 담겨 있어도 해당 파일 기준으로 한 파일로 출력됨
-  예) query_expansion_full/sample_1.json → output/retrieval/bm25_law/sample_1.json
 
 [쿼리 토크나이징]
   corpus(법령·판례)는 kiwipiepy 형태소 분석으로 토크나이징
   query는 쿼리 익스펜션 결과 bm25_keywords를 공백 제거 후 그대로 사용
   (형태소 재분리 시 복합명사 손실 문제 방지)
+
+[데이터 소스 변경]
+  CSV → DB (shared.db.connection.get_db_client 사용)
 """
+import sys
 import argparse
 import json
+import time
 import pandas as pd
 from rank_bm25 import BM25Okapi
 import kiwipiepy_model
 from kiwipiepy import Kiwi
 from pathlib import Path
+from sqlalchemy import text
 
-# ─── 경로 설정 ──────────────────────────────────────────
-_BASE   = Path(__file__).resolve().parent
+# ─── 프로젝트 루트를 sys.path에 추가 (shared 모듈 접근용) ──────────
+_BASE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_BASE.parents[1]))  # 프로젝트 루트
+from shared.db.connection import get_db_client
+
+# ─── 경로 설정 ──────────────────────────────────────────────────────
 _DATA   = _BASE / "data"
 _OUTPUT = _BASE / "output"
 
 TOP_K_CASE = 20
 TOP_K_LAW  = 20
 POS_FILTER = {"NNG", "NNP", "VV", "VA", "XR"}
-# ────────────────────────────────────────────────────────
+
+# ─── DB 테이블 및 컬럼 상수 ─────────────────────────────────────────
+# 판례: case_law 테이블에서 필요한 컬럼만 SELECT
+CASE_TABLE = "case_law"
+CASE_COLS  = "case_id, case_name, case_number, judgment_date, court_name, issue, judgment_summary"
+
+# 법령: law_child 테이블에서 필요한 컬럼만 SELECT
+LAW_TABLE = "law_child"
+LAW_COLS  = "clause_key, law_name, article_no, paragraph_no, child_text"
+# ────────────────────────────────────────────────────────────────────
 
 
-# ── 인자 파싱 ─────────────────────────────────────────────
+# ── 인자 파싱 ────────────────────────────────────────────────────────
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="BM25 통합 검색 (판례 + 법령)")
     parser.add_argument(
         "--target", choices=["case", "law", "all"], default="all",
         help="실행할 검색 대상 (default: all)",
-    )
-    parser.add_argument(
-        "--caselaw", default=str(_OUTPUT / "case_law.csv"),
-        help="판례 CSV 경로 (default: case_law.csv)",
-    )
-    parser.add_argument(
-        "--law", default=str(_DATA / "law_child.csv"),
-        help="법령 CSV 경로 (default: law_child.csv)",
     )
     parser.add_argument(
         "--samples",
@@ -76,7 +86,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-# ── Kiwi 초기화 (corpus 토크나이징 전용) ─────────────────
+# ── Kiwi 초기화 (corpus 토크나이징 전용) ────────────────────────────
 kiwi = Kiwi(model_path=str(Path(kiwipiepy_model.__file__).parent))
 
 def tokenize(text: str) -> list[str]:
@@ -91,14 +101,66 @@ def tokenize(text: str) -> list[str]:
     return tokens if tokens else text.split()
 
 def build_query_tokens(keywords: list[str]) -> list[str]:
+    """쿼리 토큰 생성: 형태소 분석 토큰 + raw 키워드(공백 제거) 보너스"""
     tokens = []
     for kw in keywords:
         tokens.extend(tokenize(kw))        # corpus와 같은 토큰 공간
         tokens.append(kw.replace(" ", "")) # raw 보너스
-    return list(dict.fromkeys(tokens))
+    return list(dict.fromkeys(tokens))     # 순서 유지 중복 제거
 
 
-# ── 샘플 로드 ─────────────────────────────────────────────
+# ── DB 데이터 로드 ───────────────────────────────────────────────────
+def load_case_law_from_db() -> pd.DataFrame:
+    """
+    DB의 case_law 테이블에서 판례 데이터 로드.
+    BM25 타겟 컬럼(bm25_target)은 issue + judgment_summary 결합으로 생성.
+    """
+    t0 = time.time()
+    print(f"▶ [판례] DB 로드 중... (테이블: {CASE_TABLE})", end=" ", flush=True)
+
+    db   = get_db_client()
+    rows = db.fetch_all(
+        text(f"SELECT {CASE_COLS} FROM {CASE_TABLE}")
+    )
+    if not rows:
+        raise ValueError(f"테이블 '{CASE_TABLE}'에서 데이터를 가져오지 못했습니다.")
+
+    df = pd.DataFrame(rows)
+
+    # BM25 검색 대상 텍스트: issue + judgment_summary 결합
+    df["bm25_target"] = (
+        df["issue"].fillna("") + " " + df["judgment_summary"].fillna("")
+    ).str.strip()
+
+    # bm25_target이 비어있는 행 제거
+    df_valid = df[df["bm25_target"].str.len() > 0].reset_index(drop=True)
+
+    print(f"완료 ({len(df_valid)}행 유효 / 전체 {len(df)}행, {time.time()-t0:.1f}초)")
+    return df_valid
+
+
+def load_law_child_from_db() -> pd.DataFrame:
+    """
+    DB의 law_child 테이블에서 법령 데이터 로드.
+    """
+    t0 = time.time()
+    print(f"▶ [법령] DB 로드 중... (테이블: {LAW_TABLE})", end=" ", flush=True)
+
+    db   = get_db_client()
+    rows = db.fetch_all(
+        text(f"SELECT {LAW_COLS} FROM {LAW_TABLE}")
+    )
+    if not rows:
+        raise ValueError(f"테이블 '{LAW_TABLE}'에서 데이터를 가져오지 못했습니다.")
+
+    df = pd.DataFrame(rows)
+    df["child_text"] = df["child_text"].fillna("").astype(str)
+
+    print(f"완료 ({len(df)}행, {time.time()-t0:.1f}초)")
+    return df
+
+
+# ── 샘플 로드 ────────────────────────────────────────────────────────
 def load_samples_by_file(path: str) -> list[tuple[str, list]]:
     """
     입력 경로별로 (파일 stem, 샘플 리스트) 튜플 반환.
@@ -140,22 +202,17 @@ def save_json(data: list, out_dir: str, stem: str) -> None:
     print(f"  ✅ 저장: {out_path}")
 
 
-# ── 판례 BM25 매칭 ────────────────────────────────────────
+# ── 판례 BM25 매칭 ───────────────────────────────────────────────────
 def run_case_matching(args) -> None:
     print("\n" + "="*70)
-    print("▶ [판례] CSV 로드 중...")
-    df = pd.read_csv(args.caselaw, encoding="utf-8-sig")
 
-    df["bm25_target"] = (
-        df["issue"].fillna("") + " " + df["judgment_summary"].fillna("")
-    ).str.strip()
-    df_valid = df[df["bm25_target"].str.len() > 0].reset_index(drop=True)
-    print(f"  유효 판례: {len(df_valid)}개 / 전체 {len(df)}개")
+    # DB에서 로드
+    df_valid = load_case_law_from_db()
 
     print("▶ [판례] corpus 토크나이징 중...")
     corpus_tokens = []
-    for i, text in enumerate(df_valid["bm25_target"]):
-        corpus_tokens.append(tokenize(text))
+    for i, text_val in enumerate(df_valid["bm25_target"]):
+        corpus_tokens.append(tokenize(text_val))
         if (i + 1) % 100 == 0:
             print(f"  {i+1}/{len(df_valid)} 완료")
 
@@ -208,14 +265,14 @@ def run_case_matching(args) -> None:
         save_json(results, args.out_case, stem)
 
 
-# ── 법령 BM25 매칭 ────────────────────────────────────────
+# ── 법령 BM25 매칭 ───────────────────────────────────────────────────
 def run_law_matching(args) -> None:
     print("\n" + "="*70)
-    print("▶ [법령] CSV 로드 중...")
-    df = pd.read_csv(args.law, encoding="utf-8-sig")
-    df["child_text"] = df["child_text"].fillna("").astype(str)
 
-    print("▶ [법령] corpus 토크나이징 중... (31k rows, 약 1~2분)")
+    # DB에서 로드
+    df = load_law_child_from_db()
+
+    print("▶ [법령] corpus 토크나이징 중... (약 1~2분 소요)")
     corpus_tokens = [tokenize(t) for t in df["child_text"]]
     bm25 = BM25Okapi(corpus_tokens)
     print("  BM25 인덱스 완료")
@@ -262,7 +319,7 @@ def run_law_matching(args) -> None:
         save_json(results, args.out_law, stem)
 
 
-# ── 진입점 ────────────────────────────────────────────────
+# ── 진입점 ──────────────────────────────────────────────────────────
 def main() -> None:
     args = parse_args()
 


### PR DESCRIPTION
## 📝 변경 사항
- `pd.read_csv()` → `get_db_client().fetch_all()`로 교체
- `load_case_law_from_db()`, `load_law_child_from_db()` 함수 추가
- 판례 검색 대상 텍스트 `bm25_target` 컬럼을 `issue` + `judgment_summary` 결합으로 코드 내 직접 생성
- `--caselaw`, `--law` CSV 경로 CLI 인자 제거

## 🔗 관련 이슈
closes #67

## 📸 스크린샷 (선택)
없음

## 🧪 테스트
- `bm25_retrieval.py` 실행 후 `case_law`, `law_child` 테이블에서 정상 로드 확인
- 기존과 동일하게 특약별 BM25 검색 결과 JSON 출력 확인

## ✅ 체크리스트
- [X] 코드가 정상적으로 동작합니다.
- [X] 커밋 메시지가 컨벤션을 따릅니다.
- [X] 셀프 리뷰를 완료했습니다.

## 💬 리뷰어에게
- `bm25_target` 생성 로직(`issue` + `judgment_summary` 결합)이 기존 CSV의 컬럼과 동일하게 동작하는지 검토 부탁드립니다.
- `sys.path` depth가 실제 프로젝트 구조와 맞는지 확인 부탁드립니다.