### PR TITLE
[Feature] Legal Retrieval 평가셋 생성 및 recall@K 평가 자동화 (#70)

### DIFF
--- a/data/processors/validation_dataset_processor.py
+++ b/data/processors/validation_dataset_processor.py
@@ -1,0 +1,1063 @@
+"""Load Cloud SQL validation exports for the legal retrieval eval dataset."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Literal
+
+from pydantic import BaseModel, Field
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+CASE_EXPORT_NAME = "val_data_from_cloudsql_case.json"
+QA_EXPORT_NAME = "val_data_from_cloudsql_qa.json"
+
+
+class ExportFormat(str, Enum):
+    CASE_LAW = "case_law"
+    QA = "qa"
+
+
+CASE_EXPORT_FIELDS = {
+    "case_id",
+    "case_number",
+    "issue",
+    "judgment_summary",
+    "case_detail",
+    "gt_laws",
+    "gt_cases",
+}
+QA_EXPORT_FIELDS = {
+    "answer_id",
+    "question_id",
+    "question_body",
+    "answer_body",
+    "referenced_laws",
+    "referenced_cases",
+}
+EXPORT_REQUIRED_FIELDS = {
+    ExportFormat.CASE_LAW: CASE_EXPORT_FIELDS,
+    ExportFormat.QA: QA_EXPORT_FIELDS,
+}
+EXPORT_REQUIRED_VALUE_FIELDS = {
+    ExportFormat.CASE_LAW: {"case_id"},
+    ExportFormat.QA: {"answer_id", "question_id"},
+}
+EXPORT_TEXT_FIELDS = {
+    ExportFormat.CASE_LAW: {
+        "case_number",
+        "issue",
+        "judgment_summary",
+        "case_detail",
+        "case_name",
+        "judgment_date",
+        "court_name",
+    },
+    ExportFormat.QA: {
+        "question_title",
+        "question_body",
+        "answer_body",
+    },
+}
+EXPORT_ARRAY_FIELDS = {
+    ExportFormat.CASE_LAW: {"gt_laws", "gt_cases"},
+    ExportFormat.QA: {"referenced_laws", "referenced_cases"},
+}
+EVAL_SET_FIELDS = {
+    "id",
+    "source_type",
+    "source_id",
+    "source_text",
+    "clauses",
+    "gt_laws",
+    "gt_cases",
+    "meta",
+}
+CLAUSE_FIELDS = {"raw", "normalized", "clause_type"}
+STAGE1_MODEL = "gemini-2.5-pro"
+STAGE1_TEMPERATURE = 0.0
+STAGE2_MODEL = "gemini-2.5-pro"
+STAGE2_TEMPERATURE = 0.0
+SAMPLE_REVIEW_SIZE = 5
+MIN_LLM_WORKERS = 5
+MAX_LLM_WORKERS = 8
+DEFAULT_LLM_WORKERS = 6
+MAX_LLM_RETRIES = 3
+CHECKPOINT_BATCH_SIZE = 10
+
+
+class Stage1ClauseExtraction(BaseModel):
+    """Structured JSON output expected from the stage 1 clause extractor."""
+
+    clause_type: Literal["explicit_quote", "paraphrased", "mention_only"]
+    is_evaluable: bool
+    extracted_clauses: list[str] = Field(default_factory=list)
+    source_field: str | None = None
+    reasoning: str
+
+
+class Stage2ClauseNormalization(BaseModel):
+    """Structured JSON output expected from the stage 2 clause normalizer."""
+
+    normalized: str
+    info_preserved: bool
+    notes: str
+
+
+@dataclass(frozen=True)
+class CloudSQLExports:
+    case_rows: list[dict[str, Any]]
+    qa_rows: list[dict[str, Any]]
+    case_path: Path
+    qa_path: Path
+
+
+@dataclass(frozen=True)
+class IntermediateEvalRecord:
+    source_type: str
+    source_id: int | str
+    source_text: dict[str, str]
+    gt_laws: list[str]
+    gt_cases: list[str]
+    meta: dict[str, Any]
+
+
+class SampleReviewRequired(RuntimeError):
+    """Raised when full processing must wait for human review of stage 1 samples."""
+
+    def __init__(self, samples: list[dict[str, Any]]) -> None:
+        self.samples = samples
+        super().__init__(
+            "Human approval required after reviewing 5 QA and 5 case_law "
+            "stage 1 samples. Re-run with --sample-review-approved after approval."
+        )
+
+
+def parse_cloudsql_text_array(value: Any) -> list[str]:
+    """Parse Postgres text[] values exported as strings such as {a,b}."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    if not isinstance(value, str):
+        return [str(value)]
+
+    text = value.strip()
+    if text in {"", "{}"}:
+        return []
+    if not (text.startswith("{") and text.endswith("}")):
+        return [text]
+
+    inner = text[1:-1]
+    if not inner:
+        return []
+    return [item for item in next(csv.reader([inner])) if item]
+
+
+def coerce_export_id(value: Any) -> int | str:
+    """Keep numeric export IDs easy to compare while preserving non-numeric IDs."""
+    text = str(value)
+    return int(text) if text.isdecimal() else text
+
+
+def append_unique(items: list[str], additions: list[str]) -> None:
+    for item in additions:
+        if item not in items:
+            items.append(item)
+
+
+def stable_scalar_sort_key(value: Any) -> tuple[int, int | str]:
+    """Sort numeric IDs by value and other IDs by text for repeatable output."""
+    text = str(value)
+    return (0, int(text)) if text.isdecimal() else (1, text)
+
+
+def has_clause_keyword(text: str) -> bool:
+    return "특약" in text or "조항" in text
+
+
+def normalize_case_gt_law_key(law_key: str) -> str:
+    """Case-law exports include a display suffix that retrieval keys do not use."""
+    return law_key.removesuffix("_조문")
+
+
+def case_law_has_clause_keyword(row: dict[str, Any]) -> bool:
+    """Case-law candidates are filtered only by legal text fields from SQL."""
+    return any(
+        has_clause_keyword(row.get(field) or "")
+        for field in ("issue", "judgment_summary", "case_detail")
+    )
+
+
+def build_stage1_extraction_prompt(source_type: str, source_text: dict[str, str]) -> str:
+    """Build the stage 1 prompt without importing any Vertex AI client."""
+    text_lines = "\n".join(f"[{key}]\n{value}" for key, value in source_text.items())
+    return f"""
+다음 {source_type} 자료에서 평가 가능한 계약 특약/조항을 추출하세요.
+
+분류 기준:
+- explicit_quote: 원문에 계약 조항 문장이 그대로 인용되어 있음
+- paraphrased: 조항 내용이 판결문 또는 상담문 안에서 의미상 재서술됨
+- mention_only: 특약/조항이라는 말만 있고 평가할 구체 내용이 없음
+
+규칙:
+- is_evaluable은 검색 평가 쿼리로 쓸 구체 조항 내용이 있을 때만 true입니다.
+- mention_only이면 is_evaluable=false이고 extracted_clauses는 빈 배열입니다.
+- 출력은 지정된 JSON schema만 따르세요.
+
+자료:
+{text_lines}
+""".strip()
+
+
+def build_stage2_normalization_prompt(raw_clause: str) -> str:
+    """Build the stage 2 prompt without importing any Vertex AI client."""
+    return f"""
+다음 계약 특약/조항 표현을 검색 평가에 적합한 한 문장으로 정규화하세요.
+
+규칙:
+- 원문의 법적 의미와 핵심 조건을 보존하세요.
+- 생략된 주어가 명확하면 자연스럽게 보충하세요.
+- 새로운 조건, 금액, 기간, 법률 효과를 만들지 마세요.
+- 출력은 지정된 JSON schema만 따르세요.
+
+원문:
+{raw_clause}
+""".strip()
+
+
+def retryable_api_exception_types() -> tuple[type[Exception], ...]:
+    try:
+        from google.api_core.exceptions import ResourceExhausted, ServiceUnavailable
+    except ImportError:  # pragma: no cover - local tests install google-api-core
+        return ()
+    return (ResourceExhausted, ServiceUnavailable)
+
+
+def is_retryable_llm_error(error: Exception) -> bool:
+    """Retry only quota/service API failures and JSON decoding failures."""
+    retryable_api_errors = retryable_api_exception_types()
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, json.JSONDecodeError):
+            return True
+        if retryable_api_errors and isinstance(current, retryable_api_errors):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def run_llm_call_with_retries(call: Callable[[], Any]) -> Any:
+    for attempt in range(MAX_LLM_RETRIES + 1):
+        try:
+            return call()
+        except Exception as error:
+            if attempt == MAX_LLM_RETRIES or not is_retryable_llm_error(error):
+                raise
+    raise RuntimeError("unreachable LLM retry state")
+
+
+def extract_stage1_clauses(
+    source_type: str,
+    source_text: dict[str, str],
+    *,
+    client: Any | None = None,
+) -> Stage1ClauseExtraction:
+    """Run stage 1 extraction with the required deterministic Gemini config."""
+    if client is None:
+        from shared.llm.gemini_client import gemini_client
+
+        client = gemini_client
+
+    result = run_llm_call_with_retries(
+        lambda: client.generate(
+            build_stage1_extraction_prompt(source_type, source_text),
+            model=STAGE1_MODEL,
+            temperature=STAGE1_TEMPERATURE,
+            response_schema=Stage1ClauseExtraction,
+        )
+    )
+    if isinstance(result, Stage1ClauseExtraction):
+        return result
+    if isinstance(result, dict):
+        return Stage1ClauseExtraction.model_validate(result)
+    if isinstance(result, str):
+        return Stage1ClauseExtraction.model_validate_json(result)
+    raise TypeError(f"Unsupported stage 1 response type: {type(result).__name__}")
+
+
+def normalize_stage2_clause(
+    raw_clause: str,
+    *,
+    client: Any | None = None,
+) -> Stage2ClauseNormalization:
+    """Run stage 2 normalization with the required deterministic Gemini config."""
+    if client is None:
+        from shared.llm.gemini_client import gemini_client
+
+        client = gemini_client
+
+    result = run_llm_call_with_retries(
+        lambda: client.generate(
+            build_stage2_normalization_prompt(raw_clause),
+            model=STAGE2_MODEL,
+            temperature=STAGE2_TEMPERATURE,
+            response_schema=Stage2ClauseNormalization,
+        )
+    )
+    if isinstance(result, Stage2ClauseNormalization):
+        return result
+    if isinstance(result, dict):
+        return Stage2ClauseNormalization.model_validate(result)
+    if isinstance(result, str):
+        return Stage2ClauseNormalization.model_validate_json(result)
+    raise TypeError(f"Unsupported stage 2 response type: {type(result).__name__}")
+
+
+def build_final_clauses_from_stage1(
+    stage1: Stage1ClauseExtraction,
+    *,
+    normalize_stage2: Callable[[str], Stage2ClauseNormalization] = normalize_stage2_clause,
+) -> list[dict[str, str]]:
+    """Convert stage 1 extraction output into final eval_set clause objects."""
+    if not stage1.is_evaluable or stage1.clause_type == "mention_only":
+        return []
+
+    clauses: list[dict[str, str]] = []
+    for raw_clause in stage1.extracted_clauses:
+        raw = raw_clause.strip()
+        if not raw:
+            continue
+        if stage1.clause_type == "explicit_quote":
+            normalized = raw
+        else:
+            # Paraphrased clauses need a second LLM pass before retrieval evaluation.
+            normalized = normalize_stage2(raw).normalized
+
+        clauses.append(
+            {
+                "raw": raw,
+                "normalized": normalized,
+                "clause_type": stage1.clause_type,
+            }
+        )
+
+    return clauses
+
+
+def load_checkpoint_records(checkpoint: Path) -> dict[str, dict[str, Any]]:
+    """Load completed checkpoint rows by eval record id."""
+    if not checkpoint.exists():
+        return {}
+
+    checkpoint_records = load_json_array(checkpoint)
+    validate_eval_set_records(checkpoint_records)
+
+    records_by_id: dict[str, dict[str, Any]] = {}
+    for index, record in enumerate(checkpoint_records):
+        record_id = str(record["id"])
+        if record_id in records_by_id:
+            raise ValueError(f"{checkpoint} row {index} duplicates id {record_id}")
+        records_by_id[record_id] = record
+    return records_by_id
+
+
+def write_checkpoint_records(
+    checkpoint: Path,
+    results: list[dict[str, Any] | None],
+) -> None:
+    """Write completed records in eval_set order so resume stays deterministic."""
+    completed = [record for record in results if record is not None]
+    validate_eval_set_records(completed)
+    checkpoint.parent.mkdir(parents=True, exist_ok=True)
+    checkpoint.write_text(
+        json.dumps(completed, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def process_eval_records_with_llm(
+    records: list[dict[str, Any]],
+    *,
+    max_workers: int = DEFAULT_LLM_WORKERS,
+    extract_stage1: Callable[[str, dict[str, str]], Stage1ClauseExtraction] = extract_stage1_clauses,
+    normalize_stage2: Callable[[str], Stage2ClauseNormalization] = normalize_stage2_clause,
+    checkpoint_path: Path | str | None = None,
+) -> list[dict[str, Any]]:
+    """Apply stage 1 and needed stage 2 LLM work with bounded item concurrency."""
+    validate_eval_set_records(records)
+    if not MIN_LLM_WORKERS <= max_workers <= MAX_LLM_WORKERS:
+        raise ValueError(
+            f"max_workers must be between {MIN_LLM_WORKERS} and {MAX_LLM_WORKERS}"
+        )
+    checkpoint = Path(checkpoint_path) if checkpoint_path is not None else None
+    checkpoint_records = load_checkpoint_records(checkpoint) if checkpoint is not None else {}
+    results: list[dict[str, Any] | None] = [None] * len(records)
+    pending: list[tuple[int, dict[str, Any]]] = []
+
+    for index, record in enumerate(records):
+        record_id = str(record.get("id", ""))
+        checkpoint_record = checkpoint_records.get(record_id)
+        checkpoint_error = (
+            (checkpoint_record.get("meta") or {}).get("processing_error")
+            if checkpoint_record is not None
+            else None
+        )
+        if checkpoint_record is not None and checkpoint_error is None:
+            results[index] = checkpoint_records[record_id]
+        else:
+            pending.append((index, record))
+
+    def process_one(record: dict[str, Any]) -> dict[str, Any]:
+        item = dict(record)
+        item["meta"] = dict(record.get("meta", {}))
+        try:
+            stage1 = extract_stage1(item["source_type"], item["source_text"])
+            item["clauses"] = build_final_clauses_from_stage1(
+                stage1,
+                normalize_stage2=normalize_stage2,
+            )
+            item["meta"]["stage1"] = stage1.model_dump()
+        except Exception as error:
+            item["clauses"] = []
+            item["meta"]["processing_error"] = {
+                "type": type(error).__name__,
+                "message": str(error),
+            }
+        return item
+
+    completed_count = sum(1 for record in results if record is not None)
+    pending_index = 0
+    while pending_index < len(pending):
+        to_next_checkpoint = CHECKPOINT_BATCH_SIZE - (
+            completed_count % CHECKPOINT_BATCH_SIZE
+        )
+        batch_size = min(to_next_checkpoint or CHECKPOINT_BATCH_SIZE, len(pending) - pending_index)
+        batch = pending[pending_index : pending_index + batch_size]
+        batch_results: list[tuple[int, dict[str, Any]] | None] = [None] * len(batch)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(process_one, record): batch_position
+                for batch_position, (_record_index, record) in enumerate(batch)
+            }
+            for future in as_completed(futures):
+                record_index, _record = batch[futures[future]]
+                batch_results[futures[future]] = (record_index, future.result())
+
+        for batch_result in batch_results:
+            if batch_result is None:
+                continue
+            record_index, processed_record = batch_result
+            results[record_index] = processed_record
+            completed_count += 1
+
+        pending_index += batch_size
+        if checkpoint is not None and completed_count % CHECKPOINT_BATCH_SIZE == 0:
+            write_checkpoint_records(checkpoint, results)
+
+    processed = [record for record in results if record is not None]
+    validate_eval_set_records(processed)
+    return processed
+
+
+def missing_fields(row: dict[str, Any], required_fields: set[str]) -> list[str]:
+    return sorted(field for field in required_fields if field not in row)
+
+
+def require_fields(
+    row: dict[str, Any],
+    required_fields: set[str],
+    label: str,
+) -> None:
+    """Raise one consistent error for records that cannot be processed."""
+    missing = missing_fields(row, required_fields)
+    if missing:
+        raise ValueError(f"{label} missing required fields: {', '.join(missing)}")
+
+
+def require_values(
+    row: dict[str, Any],
+    required_fields: set[str],
+    label: str,
+) -> None:
+    """Raise a clear error when source identifiers are blank or null."""
+    missing = sorted(
+        field
+        for field in required_fields
+        if row.get(field) is None or str(row.get(field)).strip() == ""
+    )
+    if missing:
+        raise ValueError(f"{label} missing required values: {', '.join(missing)}")
+
+
+def validate_export_field_values(
+    row: dict[str, Any],
+    export_format: ExportFormat,
+    label: str,
+) -> None:
+    """Reject malformed values before parsing so outcomes do not depend on Python coercion."""
+    for field in sorted(EXPORT_REQUIRED_VALUE_FIELDS[export_format]):
+        if isinstance(row.get(field), (dict, list)):
+            raise ValueError(f"{label} {field} must be a scalar value")
+
+    for field in sorted(EXPORT_TEXT_FIELDS[export_format] & set(row)):
+        if row[field] is not None and not isinstance(row[field], str):
+            raise ValueError(f"{label} {field} must be str or null")
+
+    for field in sorted(EXPORT_ARRAY_FIELDS[export_format]):
+        value = row.get(field)
+        if value is None or isinstance(value, str):
+            continue
+        if not isinstance(value, list):
+            raise ValueError(
+                f"{label} {field} must be a Postgres text array string, list, or null"
+            )
+        for item_index, item in enumerate(value):
+            if item is not None and not isinstance(item, (str, int, float, bool)):
+                raise ValueError(f"{label} {field}[{item_index}] must be scalar or null")
+
+
+def resolve_export_path(project_root: Path, file_name: str) -> Path:
+    """Find an export in supported repo locations."""
+    candidates = [
+        project_root / "data" / file_name,
+        project_root / "data" / "eval" / file_name,
+    ]
+
+    for path in candidates:
+        if path.exists():
+            return path
+
+    searched = ", ".join(str(path) for path in candidates)
+    raise FileNotFoundError(f"Could not find {file_name}. Searched: {searched}")
+
+
+def load_json_array(path: Path) -> list[dict[str, Any]]:
+    """Load a JSON file that must contain a list of objects."""
+    with path.open(encoding="utf-8") as input_file:
+        rows = json.load(input_file)
+
+    if not isinstance(rows, list):
+        raise ValueError(f"{path} must contain a JSON array")
+
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"{path} row {index} must be a JSON object")
+
+    return rows
+
+
+def identify_export_format(rows: list[dict[str, Any]]) -> ExportFormat:
+    """Identify the Cloud SQL export shape from its row fields."""
+    if not rows:
+        raise ValueError("Cannot identify export format from an empty JSON array")
+
+    row_fields = set(rows[0])
+    if CASE_EXPORT_FIELDS <= row_fields:
+        return ExportFormat.CASE_LAW
+    if QA_EXPORT_FIELDS <= row_fields:
+        return ExportFormat.QA
+
+    known_fields = sorted(CASE_EXPORT_FIELDS | QA_EXPORT_FIELDS)
+    actual_fields = sorted(row_fields)
+    raise ValueError(
+        "Unknown validation export format. "
+        f"Expected fields for case_law or qa export; got {actual_fields}. "
+        f"Known fields include {known_fields}"
+    )
+
+
+def validate_export_rows(
+    rows: list[dict[str, Any]],
+    export_format: ExportFormat,
+    label: str,
+) -> None:
+    """Validate every row, not just the first row used to identify the export."""
+    required_fields = EXPORT_REQUIRED_FIELDS[export_format]
+    required_value_fields = EXPORT_REQUIRED_VALUE_FIELDS[export_format]
+    for index, row in enumerate(rows):
+        row_label = f"{label} row {index}"
+        require_fields(row, required_fields, row_label)
+        require_values(row, required_value_fields, row_label)
+        validate_export_field_values(row, export_format, row_label)
+
+
+def load_export(path: Path, expected_format: ExportFormat) -> list[dict[str, Any]]:
+    """Load an export and verify it matches the expected validation format."""
+    rows = load_json_array(path)
+    actual_format = identify_export_format(rows)
+    if actual_format != expected_format:
+        raise ValueError(
+            f"{path} expected {expected_format.value} export, "
+            f"but found {actual_format.value} export"
+        )
+    validate_export_rows(rows, expected_format, path.name)
+    return rows
+
+
+def load_cloudsql_exports(project_root: Path | str | None = None) -> CloudSQLExports:
+    """Locate and load the QA and case-law Cloud SQL export files."""
+    root = (
+        Path(project_root)
+        if project_root is not None
+        else Path(__file__).resolve().parents[2]
+    )
+    case_path = resolve_export_path(root, CASE_EXPORT_NAME)
+    qa_path = resolve_export_path(root, QA_EXPORT_NAME)
+
+    return CloudSQLExports(
+        case_rows=load_export(case_path, ExportFormat.CASE_LAW),
+        qa_rows=load_export(qa_path, ExportFormat.QA),
+        case_path=case_path,
+        qa_path=qa_path,
+    )
+
+
+def parse_qa_records(rows: list[dict[str, Any]]) -> list[IntermediateEvalRecord]:
+    """Group QA answer exports by question_id and union answer-level GT."""
+    grouped: dict[Any, dict[str, Any]] = {}
+
+    for index, row in enumerate(rows):
+        row_label = f"qa row {index}"
+        require_fields(row, QA_EXPORT_FIELDS, row_label)
+        require_values(row, EXPORT_REQUIRED_VALUE_FIELDS[ExportFormat.QA], row_label)
+        validate_export_field_values(row, ExportFormat.QA, row_label)
+        question_id = coerce_export_id(row["question_id"])
+        if question_id not in grouped:
+            grouped[question_id] = {
+                "question_id": question_id,
+                "question_title": row.get("question_title") or "",
+                "question_body": row.get("question_body") or "",
+                "answer_ids": [],
+                "gt_laws": [],
+                "gt_cases": [],
+            }
+
+        group = grouped[question_id]
+        question_body = row.get("question_body") or ""
+        if question_body and not has_clause_keyword(group["question_body"]):
+            # Duplicate answer rows can carry a stale body; keep the body that can be evaluated.
+            group["question_body"] = question_body
+        group["answer_ids"].append(coerce_export_id(row["answer_id"]))
+        append_unique(group["gt_laws"], parse_cloudsql_text_array(row.get("referenced_laws")))
+        append_unique(group["gt_cases"], parse_cloudsql_text_array(row.get("referenced_cases")))
+
+    records: list[IntermediateEvalRecord] = []
+    groups = sorted(
+        grouped.values(),
+        key=lambda group: stable_scalar_sort_key(group["question_id"]),
+    )
+    for group in groups:
+        gt_laws = sorted(group["gt_laws"])
+        gt_cases = sorted(group["gt_cases"])
+        question_body = group["question_body"]
+        if not has_clause_keyword(question_body) or (not gt_laws and not gt_cases):
+            continue
+
+        records.append(
+            IntermediateEvalRecord(
+                source_type="qa",
+                source_id=group["question_id"],
+                source_text={"question_body": question_body},
+                gt_laws=gt_laws,
+                gt_cases=gt_cases,
+                meta={
+                    "question_title": group["question_title"],
+                    "answer_ids": sorted(group["answer_ids"], key=stable_scalar_sort_key),
+                    "n_answers": len(group["answer_ids"]),
+                },
+            )
+        )
+
+    return records
+
+
+def parse_case_law_records(rows: list[dict[str, Any]]) -> list[IntermediateEvalRecord]:
+    """Map case-law exports to the shared intermediate evaluation shape."""
+    records: list[IntermediateEvalRecord] = []
+
+    sorted_rows = sorted(
+        rows,
+        key=lambda row: stable_scalar_sort_key(row.get("case_id", "")),
+    )
+    for index, row in enumerate(sorted_rows):
+        row_label = f"case_law row {index}"
+        require_fields(row, CASE_EXPORT_FIELDS, row_label)
+        require_values(
+            row,
+            EXPORT_REQUIRED_VALUE_FIELDS[ExportFormat.CASE_LAW],
+            row_label,
+        )
+        validate_export_field_values(row, ExportFormat.CASE_LAW, row_label)
+        gt_laws = sorted(
+            normalize_case_gt_law_key(law_key)
+            for law_key in parse_cloudsql_text_array(row.get("gt_laws"))
+        )
+        gt_cases = sorted(parse_cloudsql_text_array(row.get("gt_cases")))
+        if (not gt_laws and not gt_cases) or not case_law_has_clause_keyword(row):
+            continue
+
+        records.append(
+            IntermediateEvalRecord(
+                source_type="case_law",
+                source_id=coerce_export_id(row["case_id"]),
+                source_text={
+                    "issue": row.get("issue") or "",
+                    "judgment_summary": row.get("judgment_summary") or "",
+                    "case_detail": row.get("case_detail") or "",
+                },
+                gt_laws=gt_laws,
+                gt_cases=gt_cases,
+                meta={
+                    "case_name": row.get("case_name") or "",
+                    "case_number": row.get("case_number") or "",
+                    "judgment_date": row.get("judgment_date") or "",
+                    "court_name": row.get("court_name") or "",
+                },
+            )
+        )
+
+    return records
+
+
+def build_eval_record_id(source_type: str, source_id: int | str) -> str:
+    """Use stable IDs that show the source family at a glance."""
+    prefix = "case" if source_type == "case_law" else source_type
+    return f"{prefix}_{source_id}"
+
+
+def build_stage1_review_samples(
+    records: list[IntermediateEvalRecord],
+    *,
+    extract_stage1: Callable[
+        [str, dict[str, str]],
+        Stage1ClauseExtraction,
+    ] = extract_stage1_clauses,
+) -> list[dict[str, Any]]:
+    """Run stage 1 on the required human-review samples before full processing."""
+    records_by_type: dict[str, list[IntermediateEvalRecord]] = {}
+    for source_type in ("qa", "case_law"):
+        source_records = [record for record in records if record.source_type == source_type]
+        if len(source_records) < SAMPLE_REVIEW_SIZE:
+            raise ValueError(
+                "stage 1 review gate needs at least "
+                f"{SAMPLE_REVIEW_SIZE} {source_type} records"
+            )
+        records_by_type[source_type] = source_records
+
+    samples: list[dict[str, Any]] = []
+    for source_type in ("qa", "case_law"):
+        for record in records_by_type[source_type][:SAMPLE_REVIEW_SIZE]:
+            stage1 = extract_stage1(record.source_type, record.source_text)
+            samples.append(
+                {
+                    "id": build_eval_record_id(record.source_type, record.source_id),
+                    "source_type": record.source_type,
+                    "source_id": record.source_id,
+                    "source_text": dict(record.source_text),
+                    "gt_laws": list(record.gt_laws),
+                    "gt_cases": list(record.gt_cases),
+                    "meta": dict(record.meta),
+                    "stage1": stage1.model_dump(),
+                }
+            )
+
+    return samples
+
+
+def validate_eval_set_records(records: list[dict[str, Any]]) -> None:
+    """Validate the shared eval_set.json schema before writing or evaluating."""
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            raise ValueError(f"eval_set row {index} must be a JSON object")
+
+        label = f"eval_set row {index}"
+        require_fields(record, EVAL_SET_FIELDS, label)
+        if not isinstance(record["id"], str) or not record["id"].strip():
+            raise ValueError(f"{label} id must be a non-empty string")
+        if isinstance(record["source_id"], (dict, list)) or not str(record["source_id"]).strip():
+            raise ValueError(f"{label} source_id must be a non-empty scalar")
+        if not record["gt_laws"] and not record["gt_cases"]:
+            raise ValueError(f"{label} must have gt_laws or gt_cases")
+
+        if record["source_type"] not in {"qa", "case_law"}:
+            raise ValueError(f"{label} source_type must be qa or case_law")
+
+        typed_fields = {
+            "source_text": dict,
+            "clauses": list,
+            "gt_laws": list,
+            "gt_cases": list,
+            "meta": dict,
+        }
+        for field, expected_type in typed_fields.items():
+            if not isinstance(record[field], expected_type):
+                raise ValueError(f"{label} {field} must be {expected_type.__name__}")
+
+        if record["source_type"] == "qa":
+            question_body = record["source_text"].get("question_body")
+            if not isinstance(question_body, str) or not has_clause_keyword(question_body):
+                raise ValueError(
+                    f"{label} qa source_text.question_body must contain 특약 or 조항"
+                )
+        if record["source_type"] == "case_law" and not case_law_has_clause_keyword(
+            record["source_text"]
+        ):
+            raise ValueError(
+                f"{label} case_law source_text.issue, judgment_summary, "
+                "or case_detail must contain 특약 or 조항"
+            )
+
+        for clause_index, clause in enumerate(record["clauses"]):
+            if not isinstance(clause, dict):
+                raise ValueError(f"{label} clause {clause_index} must be a JSON object")
+            clause_label = f"{label} clause {clause_index}"
+            require_fields(
+                clause,
+                CLAUSE_FIELDS,
+                clause_label,
+            )
+            if clause.get("clause_type") == "mention_only":
+                raise ValueError(f"{clause_label} mention_only must be excluded")
+            if clause.get("is_evaluable") is False:
+                raise ValueError(f"{clause_label} is_evaluable=false must be excluded")
+
+
+def normalize_eval_records(records: list[IntermediateEvalRecord]) -> list[dict[str, Any]]:
+    """Convert parsed records into the shared eval_set item schema."""
+    items: list[dict[str, Any]] = []
+    source_order = {"case_law": 0, "qa": 1}
+
+    ordered_records = sorted(
+        records,
+        key=lambda record: (
+            source_order.get(record.source_type, 99),
+            stable_scalar_sort_key(record.source_id),
+        ),
+    )
+    for record in ordered_records:
+        if not record.gt_laws and not record.gt_cases:
+            raise ValueError(
+                f"{record.source_type} {record.source_id} must have gt_laws or gt_cases"
+            )
+
+        items.append(
+            {
+                "id": build_eval_record_id(record.source_type, record.source_id),
+                "source_type": record.source_type,
+                "source_id": record.source_id,
+                "source_text": dict(record.source_text),
+                "clauses": [],
+                "gt_laws": list(record.gt_laws),
+                "gt_cases": list(record.gt_cases),
+                "meta": dict(record.meta),
+            }
+        )
+
+    validate_eval_set_records(items)
+    return items
+
+
+def build_eval_set(
+    case_rows: list[dict[str, Any]],
+    qa_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build one eval_set.json array from both Cloud SQL validation exports."""
+    validate_export_rows(case_rows, ExportFormat.CASE_LAW, "case_law input")
+    validate_export_rows(qa_rows, ExportFormat.QA, "qa input")
+    records = parse_case_law_records(case_rows) + parse_qa_records(qa_rows)
+    return normalize_eval_records(records)
+
+
+def build_eval_set_with_review_gate(
+    case_rows: list[dict[str, Any]],
+    qa_rows: list[dict[str, Any]],
+    *,
+    sample_review_approved: bool = False,
+    max_workers: int = DEFAULT_LLM_WORKERS,
+    checkpoint_path: Path | str | None = None,
+    extract_stage1: Callable[
+        [str, dict[str, str]],
+        Stage1ClauseExtraction,
+    ] = extract_stage1_clauses,
+    normalize_stage2: Callable[[str], Stage2ClauseNormalization] = normalize_stage2_clause,
+) -> list[dict[str, Any]]:
+    """Build the eval set only after required stage 1 sample review is approved."""
+    validate_export_rows(case_rows, ExportFormat.CASE_LAW, "case_law input")
+    validate_export_rows(qa_rows, ExportFormat.QA, "qa input")
+    records = parse_qa_records(qa_rows) + parse_case_law_records(case_rows)
+    if not sample_review_approved:
+        raise SampleReviewRequired(
+            build_stage1_review_samples(records, extract_stage1=extract_stage1)
+        )
+
+    processed = process_eval_records_with_llm(
+        normalize_eval_records(records),
+        max_workers=max_workers,
+        extract_stage1=extract_stage1,
+        normalize_stage2=normalize_stage2,
+        checkpoint_path=checkpoint_path,
+    )
+    final_records = [record for record in processed if record["clauses"]]
+    if not final_records:
+        raise ValueError("No evaluable records remained after LLM clause extraction")
+    validate_eval_set_records(final_records)
+    return final_records
+
+
+def write_eval_set(records: list[dict[str, Any]], project_root: Path | str) -> Path:
+    """Write records to evaluation/eval_set.json after schema validation."""
+    validate_eval_set_records(records)
+    output_path = Path(project_root) / "evaluation" / "eval_set.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(records, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def write_stage1_review_samples(
+    samples: list[dict[str, Any]],
+    project_root: Path | str,
+) -> Path:
+    """Persist stage 1 review samples so a human can approve or reject them."""
+    output_path = Path(project_root) / "evaluation" / "stage1_review_samples.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(samples, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def format_eval_set_statistics(
+    records: list[dict[str, Any]],
+    *,
+    review_samples: list[dict[str, Any]] | None = None,
+) -> list[str]:
+    """Return the required eval_set summary lines for console reporting."""
+    validate_eval_set_records(records)
+    review_samples = review_samples or []
+
+    source_counts = Counter(str(record["source_type"]) for record in records)
+    gt_availability = Counter(
+        "both"
+        if record["gt_laws"] and record["gt_cases"]
+        else "laws_only"
+        if record["gt_laws"]
+        else "cases_only"
+        for record in records
+    )
+    clause_types = Counter(
+        str(clause.get("clause_type"))
+        for record in records
+        for clause in record["clauses"]
+    )
+    clause_counts = Counter(len(record["clauses"]) for record in records)
+    gt_counts = [len(record["gt_laws"]) + len(record["gt_cases"]) for record in records]
+    review_counts = Counter(str(sample.get("source_type", "")) for sample in review_samples)
+    review_ids = ",".join(str(sample.get("id", "")) for sample in review_samples[:10])
+
+    return [
+        "Dataset statistics:",
+        "source_count "
+        f"case_law={source_counts.get('case_law', 0)} "
+        f"qa={source_counts.get('qa', 0)} total={len(records)}",
+        "gt_availability "
+        f"both={gt_availability.get('both', 0)} "
+        f"cases_only={gt_availability.get('cases_only', 0)} "
+        f"laws_only={gt_availability.get('laws_only', 0)}",
+        "clause_type "
+        f"explicit_quote={clause_types.get('explicit_quote', 0)} "
+        f"paraphrased={clause_types.get('paraphrased', 0)} "
+        f"mention_only={clause_types.get('mention_only', 0)}",
+        "clause_count_distribution "
+        + " ".join(
+            f"{count}={clause_counts[count]}" for count in sorted(clause_counts)
+        ),
+        "gt_count "
+        f"average={sum(gt_counts) / len(gt_counts):.6f} max={max(gt_counts)}",
+        "review_samples "
+        f"total={len(review_samples)} "
+        f"qa={review_counts.get('qa', 0)} "
+        f"case_law={review_counts.get('case_law', 0)} "
+        f"ids={review_ids}",
+    ]
+
+
+def load_stage1_review_samples(project_root: Path | str) -> list[dict[str, Any]]:
+    """Load saved review samples when present so final stats include the review gate."""
+    sample_path = Path(project_root) / "evaluation" / "stage1_review_samples.json"
+    if not sample_path.exists():
+        return []
+    return load_json_array(sample_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Load legal retrieval validation exports.")
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+    )
+    parser.add_argument(
+        "--sample-review-approved",
+        action="store_true",
+        help="Proceed only after a human approves the 5 QA and 5 case_law stage 1 samples.",
+    )
+    args = parser.parse_args()
+
+    try:
+        exports = load_cloudsql_exports(args.project_root)
+        eval_set = build_eval_set_with_review_gate(
+            exports.case_rows,
+            exports.qa_rows,
+            sample_review_approved=args.sample_review_approved,
+            checkpoint_path=Path(args.project_root)
+            / "evaluation"
+            / "eval_set_checkpoint.json",
+        )
+        output_path = write_eval_set(eval_set, args.project_root)
+        review_samples = load_stage1_review_samples(args.project_root)
+    except SampleReviewRequired as review:
+        output_path = write_stage1_review_samples(review.samples, args.project_root)
+        print(f"Sample review required: {review}", file=sys.stderr)
+        print(f"Wrote stage 1 review samples to {output_path}", file=sys.stderr)
+        return 2
+    except (FileNotFoundError, json.JSONDecodeError, ValueError) as error:
+        print(f"Validation failed: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Loaded {len(exports.case_rows)} case-law rows from {exports.case_path}")
+    print(f"Loaded {len(exports.qa_rows)} QA rows from {exports.qa_path}")
+    print(
+        "Parsed "
+        f"{sum(1 for record in eval_set if record['source_type'] == 'case_law')} "
+        "case-law records"
+    )
+    print(
+        f"Parsed {sum(1 for record in eval_set if record['source_type'] == 'qa')} "
+        "QA records"
+    )
+    print(f"Wrote {len(eval_set)} eval records to {output_path}")
+    for line in format_eval_set_statistics(eval_set, review_samples=review_samples):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evaluation/legal_retrieval_eval.py
+++ b/evaluation/legal_retrieval_eval.py
@@ -1323,16 +1323,16 @@ def law_reference_hit_flags(
     law_references: list[dict[str, Any]],
     results: list[dict[str, Any]],
 ) -> list[dict[str, str | bool]]:
-    result_keys = {
+    result_keys = [
         normalize_match_value(value)
         for result in results
         for value in law_match_values(result)
         if normalize_match_value(value)
-    }
+    ]
     return [
         {
             "law_child": reference["law_child"],
-            "hit": normalize_match_value(reference["law_child"]) in result_keys,
+            "hit": reference_matches_result(reference["law_child"], result_keys),
         }
         for reference in law_references
     ]
@@ -1343,16 +1343,16 @@ def precedent_hit_flags(
     precedent_references: list[dict[str, Any]],
     results: list[dict[str, Any]],
 ) -> list[dict[str, str | bool]]:
-    result_case_numbers = {
+    result_case_numbers = [
         normalize_match_value(value)
         for result in results
         for value in precedent_match_values(result)
         if normalize_match_value(value)
-    }
+    ]
     return [
         {
             "case_number": reference["case_number"],
-            "hit": normalize_match_value(reference["case_number"]) in result_case_numbers,
+            "hit": reference_matches_result(reference["case_number"], result_case_numbers),
         }
         for reference in precedent_references
     ]
@@ -1611,16 +1611,16 @@ def count_law_hits(
     law_references: list[dict[str, Any]],
     results: list[dict[str, Any]],
 ) -> int:
-    result_keys = {
+    result_keys = [
         normalize_match_value(value)
         for result in results
         for value in law_match_values(result)
         if normalize_match_value(value)
-    }
+    ]
     return sum(
         1
         for reference in law_references
-        if normalize_match_value(reference["law_child"]) in result_keys
+        if reference_matches_result(reference["law_child"], result_keys)
     )
 
 
@@ -1628,26 +1628,39 @@ def count_precedent_hits(
     precedent_references: list[dict[str, Any]],
     results: list[dict[str, Any]],
 ) -> int:
-    result_case_numbers = {
+    result_case_numbers = [
         normalize_match_value(value)
         for result in results
         for value in precedent_match_values(result)
         if normalize_match_value(value)
-    }
+    ]
     return sum(
         1
         for reference in precedent_references
-        if normalize_match_value(reference["case_number"]) in result_case_numbers
+        if reference_matches_result(reference["case_number"], result_case_numbers)
     )
 
 
 def law_match_values(result: dict[str, Any]) -> list[Any]:
     if result.get("source_type") != "law":
         return []
-    values = [result.get("clause_key")]
+    values = [
+        result.get("clause_key"),
+        result.get("law_name"),
+        result.get("article_key"),
+        result.get("result_id"),
+    ]
+    values.extend(combined_law_values(result))
     metadata = result.get("metadata")
     if isinstance(metadata, dict):
-        values.append(metadata.get("clause_key"))
+        values.extend(
+            [
+                metadata.get("clause_key"),
+                metadata.get("law_name"),
+                metadata.get("article_key"),
+            ]
+        )
+        values.extend(combined_law_values(metadata))
     return values
 
 
@@ -1655,22 +1668,40 @@ def precedent_match_values(result: dict[str, Any]) -> list[Any]:
     """Return retrieved precedent identifiers eligible for validation matching."""
     if result.get("source_type") != "precedent":
         return []
-    values = [result.get("case_number")]
+    values = [
+        result.get("case_number"),
+        result.get("case_name"),
+        result.get("result_id"),
+    ]
     metadata = result.get("metadata")
     if not isinstance(metadata, dict):
         return values
-    # Case recall is exact-match only on case_number, whether flat or nested.
-    values.append(metadata.get("case_number"))
+    values.extend([metadata.get("case_number"), metadata.get("case_name")])
     case_law = metadata.get("case_law")
     if isinstance(case_law, dict):
-        values.append(case_law.get("case_number"))
+        values.extend([case_law.get("case_number"), case_law.get("case_name")])
     return values
+
+
+def combined_law_values(item: dict[str, Any]) -> list[str]:
+    law_name = item.get("law_name")
+    article_key = item.get("article_key")
+    if not law_name or not article_key:
+        return []
+    return [f"{law_name}_{article_key}", f"{law_name} {article_key}"]
+
+
+def reference_matches_result(reference: Any, result_values: list[str]) -> bool:
+    normalized_reference = normalize_match_value(reference)
+    if not normalized_reference:
+        return False
+    return any(normalized_reference in result_value for result_value in result_values)
 
 
 def normalize_match_value(value: Any) -> str:
     if value is None:
         return ""
-    return str(value).strip().casefold()
+    return "".join(str(value).strip().casefold().replace("_", " ").split())
 
 
 def ratio(hits: int, total: int) -> float:

--- a/evaluation/legal_retrieval_eval.py
+++ b/evaluation/legal_retrieval_eval.py
@@ -1,12 +1,9 @@
-"""Legal retrieval evaluation CLI.
-
-Runs the first evaluation contract step: load a validation dataset from an
-absolute JSON path, validate case shape, and write an inspectable report.
-"""
+"""Helpers for legal retrieval evaluation datasets and metric matching."""
 
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import sys
 from dataclasses import dataclass, field
@@ -14,26 +11,52 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import numpy as np
+import pandas as pd
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from pipeline.reranking.evaluation_reranker import rerank_hybrid_results
-from pipeline.retrieval.evaluation_retrieval import (
-    expand_case_queries,
-    inspect_retrieved_documents,
-    run_hybrid_retrieval,
+from data.processors.validation_dataset_processor import (
+    case_law_has_clause_keyword,
+    coerce_export_id,
+    has_clause_keyword,
+    stable_scalar_sort_key,
 )
+PIPELINE_IMPORT_ERROR: ImportError | None = None
+try:
+    from pipeline.reranking import reranker as project_reranker
+    from pipeline.retrieval.bm25_retrieval import build_query_tokens, tokenize
+    from pipeline.retrieval import dense_retrieval
+    from pipeline.retrieval.evaluation_retrieval import (
+        collect_case_documents,
+        expand_case_queries,
+        inspect_retrieved_documents,
+    )
+    from rank_bm25 import BM25Okapi
+except ImportError as error:
+    PIPELINE_IMPORT_ERROR = error
 
 
 DEFAULT_RECALL_K_VALUES = [1, 3, 5, 10, 20]
 REPORT_SCHEMA_VERSION = "legal_retrieval_eval.v1"
 REQUIRED_CASE_FIELDS = ("case_id", "clauses", "law_references", "precedent_references")
+DEFAULT_INPUT_PATH = PROJECT_ROOT / "evaluation" / "eval_set.json"
 RESULTS_DIR = Path(__file__).resolve().parent / "results"
+SEMANTIC_EMBED_COL = "embed_vertex"
+LAW_SEMANTIC_EMBED_COL = "embed_vertex"
+PRECEDENT_SEMANTIC_EMBED_COL = "embedding"
+LAW_SEMANTIC_KEEP_COLS = ["clause_key", "child_text"]
+PRECEDENT_SEMANTIC_KEEP_COLS = ["case_id", "case_number", "judgment_summary"]
 
 
 class DatasetValidationError(ValueError):
     """Raised when an evaluation dataset cannot satisfy the CLI contract."""
+
+
+class PipelineImportError(RuntimeError):
+    """Raised when the real retrieval/reranking pipeline is unavailable."""
 
 
 @dataclass
@@ -57,13 +80,251 @@ class CaseExecutionContext:
         return self.case["case_id"]
 
 
+def assert_real_pipeline_imports_available() -> None:
+    if PIPELINE_IMPORT_ERROR is None:
+        return
+    raise PipelineImportError(
+        "real retrieval/reranking pipeline import failed: "
+        f"{type(PIPELINE_IMPORT_ERROR).__name__}: {PIPELINE_IMPORT_ERROR}\n"
+        "Required actions: restore the project retrieval/reranking modules and "
+        "install their dependencies, then rerun evaluation/legal_retrieval_eval.py."
+    )
+
+
+def parse_text_array(value: Any) -> list[str]:
+    """Parse Cloud SQL text-array exports such as {a,b} into Python strings."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    if not isinstance(value, str):
+        return [str(value)]
+
+    text = value.strip()
+    if text in {"", "{}"}:
+        return []
+    if not (text.startswith("{") and text.endswith("}")):
+        return [text]
+
+    inner = text[1:-1]
+    if not inner:
+        return []
+    return [item for item in next(csv.reader([inner])) if item]
+
+
+def append_unique(items: list[str], additions: list[str]) -> None:
+    for item in additions:
+        if item not in items:
+            items.append(item)
+
+
+def has_source_clause_keyword(row: dict[str, Any]) -> bool:
+    """Apply the QA and case-law keyword filters to the correct source fields."""
+    source_type = row.get("source_type")
+    source_text = row.get("source_text")
+    text_fields = source_text if isinstance(source_text, dict) else row
+
+    if source_type == "qa" or "question_body" in text_fields:
+        return has_clause_keyword(text_fields.get("question_body") or "")
+    if source_type == "case_law" or "case_id" in row:
+        return case_law_has_clause_keyword(text_fields)
+    return False
+
+
+def preprocess_qa_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Deduplicate QA rows by question_id and union answer-level GT."""
+    grouped: dict[Any, dict[str, Any]] = {}
+    for row in rows:
+        question_id = coerce_export_id(row["question_id"])
+        if question_id not in grouped:
+            grouped[question_id] = {
+                "source_type": "qa",
+                "source_id": question_id,
+                "question_id": question_id,
+                "question_title": row.get("question_title") or "",
+                "question_body": row.get("question_body") or "",
+                "gt_laws": [],
+                "gt_cases": [],
+                "answer_ids": [],
+                "n_answers": 0,
+            }
+
+        group = grouped[question_id]
+        question_body = row.get("question_body") or ""
+        if question_body and not has_clause_keyword(group["question_body"]):
+            group["question_body"] = question_body
+        group["answer_ids"].append(coerce_export_id(row["answer_id"]))
+        group["n_answers"] += 1
+        append_unique(group["gt_laws"], parse_text_array(row.get("referenced_laws")))
+        append_unique(group["gt_cases"], parse_text_array(row.get("referenced_cases")))
+
+    candidates: list[dict[str, Any]] = []
+    for group in sorted(
+        grouped.values(),
+        key=lambda item: stable_scalar_sort_key(item["question_id"]),
+    ):
+        if not has_source_clause_keyword(group):
+            continue
+        if not group["gt_laws"] and not group["gt_cases"]:
+            continue
+        group["gt_laws"] = sorted(group["gt_laws"])
+        group["gt_cases"] = sorted(group["gt_cases"])
+        group["answer_ids"] = sorted(group["answer_ids"], key=stable_scalar_sort_key)
+        candidates.append(group)
+    return candidates
+
+
+def build_eval_set_from_stage_rows(
+    qa_stage_rows: list[dict[str, Any]],
+    case_stage_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build eval_set.json records after LLM stage outputs are attached."""
+    records: list[dict[str, Any]] = []
+    for row in sorted(
+        qa_stage_rows,
+        key=lambda item: stable_scalar_sort_key(item.get("question_id", "")),
+    ):
+        if not has_source_clause_keyword({**row, "source_type": "qa"}):
+            continue
+        record = eval_record_from_qa_stage_row(row)
+        if record is not None:
+            records.append(record)
+
+    for row in sorted(
+        case_stage_rows,
+        key=lambda item: stable_scalar_sort_key(item.get("case_id", "")),
+    ):
+        # The combined 특약/조항 search over issue/summary/detail is only for case-law.
+        if not has_source_clause_keyword({**row, "source_type": "case_law"}):
+            continue
+        record = eval_record_from_case_stage_row(row)
+        if record is not None:
+            records.append(record)
+
+    return records
+
+
+def eval_record_from_qa_stage_row(row: dict[str, Any]) -> dict[str, Any] | None:
+    source_id = coerce_export_id(row["question_id"])
+    return build_stage_eval_record(
+        source_type="qa",
+        source_id=source_id,
+        source_text={"question_body": row.get("question_body") or ""},
+        gt_laws=row.get("gt_laws") or [],
+        gt_cases=row.get("gt_cases") or [],
+        meta={
+            "question_title": row.get("question_title") or "",
+            "answer_ids": row.get("answer_ids") or [],
+            "n_answers": row.get("n_answers") or 0,
+        },
+        stage1=row.get("stage1") or {},
+        stage2=row.get("stage2") or [],
+    )
+
+
+def eval_record_from_case_stage_row(row: dict[str, Any]) -> dict[str, Any] | None:
+    source_id = coerce_export_id(row["case_id"])
+    return build_stage_eval_record(
+        source_type="case_law",
+        source_id=source_id,
+        source_text={
+            "issue": row.get("issue") or "",
+            "judgment_summary": row.get("judgment_summary") or "",
+            "case_detail": row.get("case_detail") or "",
+        },
+        gt_laws=row.get("gt_laws") or [],
+        gt_cases=row.get("gt_cases") or [],
+        meta={
+            "case_name": row.get("case_name") or "",
+            "case_number": row.get("case_number") or "",
+            "judgment_date": row.get("judgment_date") or "",
+            "court_name": row.get("court_name") or "",
+        },
+        stage1=row.get("stage1") or {},
+        stage2=row.get("stage2") or [],
+    )
+
+
+def build_stage_eval_record(
+    *,
+    source_type: str,
+    source_id: int | str,
+    source_text: dict[str, str],
+    gt_laws: list[str],
+    gt_cases: list[str],
+    meta: dict[str, Any],
+    stage1: dict[str, Any],
+    stage2: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    clause_type = stage1.get("clause_type")
+    if clause_type == "mention_only" or not stage1.get("is_evaluable"):
+        return None
+    clauses = stage_clauses(clause_type, stage1.get("extracted_clauses") or [], stage2)
+    if not clauses or (not gt_laws and not gt_cases):
+        return None
+    prefix = "case" if source_type == "case_law" else source_type
+    return {
+        "id": f"{prefix}_{source_id}",
+        "source_type": source_type,
+        "source_id": source_id,
+        "source_text": source_text,
+        "clauses": clauses,
+        "gt_laws": sorted(gt_laws),
+        "gt_cases": sorted(gt_cases),
+        "meta": meta,
+    }
+
+
+def stage_clauses(
+    clause_type: str,
+    extracted_clauses: list[str],
+    stage2: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    if clause_type == "explicit_quote":
+        return [
+            {"raw": clause, "normalized": clause, "clause_type": clause_type}
+            for clause in extracted_clauses
+            if clause
+        ]
+    return [
+        {
+            "raw": item["raw"],
+            "normalized": item["normalized"],
+            "clause_type": clause_type,
+        }
+        for item in stage2
+        if item.get("raw") and item.get("normalized")
+    ]
+
+
+def normalize_eval_record_for_pipeline(
+    record: dict[str, Any],
+    case_index: int,
+) -> dict[str, Any]:
+    """Convert eval_set.json shape into the older retrieval-eval case shape."""
+    return {
+        "case_id": record.get("id") or f"eval_{case_index}",
+        "clauses": [clause["normalized"] for clause in record.get("clauses", [])],
+        "law_references": [
+            {"law_child": law_key} for law_key in record.get("gt_laws", [])
+        ],
+        "precedent_references": [
+            {"case_number": case_number} for case_number in record.get("gt_cases", [])
+        ],
+        "source_type": record.get("source_type"),
+        "source_id": record.get("source_id"),
+        "source_text": record.get("source_text", {}),
+        "meta": record.get("meta", {}),
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run legal QA retrieval evaluation for a JSON array dataset."
     )
     parser.add_argument(
         "--input",
-        required=True,
+        default=str(DEFAULT_INPUT_PATH),
         help="Absolute path to a JSON array evaluation dataset.",
     )
     parser.add_argument(
@@ -96,10 +357,30 @@ def load_dataset(input_path: Path) -> list[dict[str, Any]]:
     if not isinstance(dataset, list):
         raise DatasetValidationError("input JSON must be an array of case objects")
 
-    for index, case in enumerate(dataset):
+    normalized_dataset = [
+        normalize_eval_record_for_pipeline(case, index)
+        if is_eval_set_record(case)
+        else case
+        for index, case in enumerate(dataset)
+    ]
+
+    for index, case in enumerate(normalized_dataset):
         validate_case(case, index)
 
-    return dataset
+    return normalized_dataset
+
+
+def is_eval_set_record(case: Any) -> bool:
+    return isinstance(case, dict) and {
+        "id",
+        "source_type",
+        "source_id",
+        "source_text",
+        "clauses",
+        "gt_laws",
+        "gt_cases",
+        "meta",
+    }.issubset(case)
 
 
 def validate_case(case: Any, index: int) -> None:
@@ -196,7 +477,11 @@ def run_case_pipeline(context: CaseExecutionContext) -> None:
         record_stage(context, current_stage, len(context.expanded_queries))
 
         current_stage = "hybrid_retrieval"
-        keyword_results, semantic_results = run_hybrid_retrieval(
+        keyword_results = run_bm25_retrieval(
+            case=context.case,
+            expanded_queries=context.expanded_queries,
+        )
+        semantic_results = run_semantic_retrieval(
             case=context.case,
             expanded_queries=context.expanded_queries,
         )
@@ -210,7 +495,7 @@ def run_case_pipeline(context: CaseExecutionContext) -> None:
 
         current_stage = "reranking"
         context.reranked_results.extend(
-            rerank_hybrid_results(
+            run_project_reranking(
                 keyword_results=context.keyword_results,
                 semantic_results=context.semantic_results,
             )
@@ -239,6 +524,313 @@ def run_case_pipeline(context: CaseExecutionContext) -> None:
         )
 
 
+def run_bm25_retrieval(
+    *,
+    case: dict[str, Any],
+    expanded_queries: list[dict[str, Any]],
+    top_k: int = 20,
+) -> list[dict[str, Any]]:
+    """Run the project BM25 tokenizer/query path against case-local documents."""
+    documents = collect_case_documents(case)
+    if not documents:
+        return []
+
+    corpus_tokens = [tokenize(document["search_text"]) for document in documents]
+    bm25 = BM25Okapi(corpus_tokens)
+    results: list[dict[str, Any]] = []
+
+    for query in expanded_queries:
+        keywords = query["retrieval_payload"]["bm25_keywords"]
+        query_tokens = build_query_tokens(keywords)
+        scores = bm25.get_scores(query_tokens)
+        top_indexes = sorted(
+            range(len(scores)),
+            key=lambda document_index: scores[document_index],
+            reverse=True,
+        )[:top_k]
+
+        for rank, document_index in enumerate(top_indexes, 1):
+            document = documents[document_index]
+            score = round(float(scores[document_index]), 6)
+            results.append(
+                {
+                    "clause_index": query["clause_index"],
+                    "clause": query["clause"],
+                    "result_id": document["result_id"],
+                    "source_type": document["source_type"],
+                    "score": score,
+                    "keyword_score": score,
+                    "retrieval_method": "bm25",
+                    "rank": rank,
+                    "document_body": document["document_body"],
+                    "document_text": document["document_text"],
+                    "metadata": document["metadata"],
+                    "query_tokens": query_tokens,
+                }
+            )
+
+    return results
+
+
+def run_semantic_retrieval(
+    *,
+    expanded_queries: list[dict[str, Any]],
+    case: dict[str, Any] | None = None,
+    top_k: int = 20,
+    embed_col: str = SEMANTIC_EMBED_COL,
+) -> list[dict[str, Any]]:
+    """Run semantic retrieval through the project's dense retriever module."""
+    case_documents = collect_case_documents(case) if case is not None else []
+    if case_documents:
+        return run_case_local_semantic_retrieval(
+            case=case,
+            expanded_queries=expanded_queries,
+            top_k=top_k,
+        )
+    if case is not None and not is_real_eval_case(case):
+        return []
+
+    law_chunks = dense_retrieval.load_chunks(
+        dense_retrieval.LAW_TABLE,
+        LAW_SEMANTIC_EMBED_COL,
+        LAW_SEMANTIC_KEEP_COLS,
+    )
+    precedent_chunks = dense_retrieval.load_chunks(
+        dense_retrieval.PREC_TABLE,
+        PRECEDENT_SEMANTIC_EMBED_COL,
+        PRECEDENT_SEMANTIC_KEEP_COLS,
+    )
+
+    results: list[dict[str, Any]] = []
+    for query in expanded_queries:
+        dense_query = query["retrieval_payload"]["dense_query"]
+        query_vec = dense_retrieval.embed_query(dense_query, embed_col)
+        results.extend(
+            semantic_results_from_rows(
+                query=query,
+                rows=dense_retrieval.search_similar(
+                    query_vec,
+                    law_chunks,
+                    LAW_SEMANTIC_EMBED_COL,
+                    top_k,
+                ),
+                source_type="law",
+            )
+        )
+        results.extend(
+            semantic_results_from_rows(
+                query=query,
+                rows=dense_retrieval.search_similar(
+                    query_vec,
+                    precedent_chunks,
+                    PRECEDENT_SEMANTIC_EMBED_COL,
+                    top_k,
+                ),
+                source_type="precedent",
+            )
+        )
+    return results
+
+
+def is_real_eval_case(case: dict[str, Any]) -> bool:
+    return {"source_type", "source_id", "source_text", "meta"}.issubset(case)
+
+
+def run_case_local_semantic_retrieval(
+    *,
+    case: dict[str, Any],
+    expanded_queries: list[dict[str, Any]],
+    top_k: int,
+) -> list[dict[str, Any]]:
+    """Use project dense ranking on inline documents used by tests and examples."""
+    documents = collect_case_documents(case)
+    texts = [query["retrieval_payload"]["dense_query"] for query in expanded_queries]
+    texts.extend(document["search_text"] for document in documents)
+    vocabulary = sorted({token for text in texts for token in tokenize(text)})
+    if not vocabulary:
+        return []
+
+    token_index = {token: index for index, token in enumerate(vocabulary)}
+    document_frame = pd.DataFrame(
+        [
+            {
+                **document,
+                "_vec": vectorize_text(document["search_text"], token_index),
+            }
+            for document in documents
+        ]
+    )
+
+    results: list[dict[str, Any]] = []
+    dense_retrieval.MIN_SIMILARITY.setdefault("case_local", 0.0)
+    for query in expanded_queries:
+        query_vec = vectorize_text(query["retrieval_payload"]["dense_query"], token_index)
+        results.extend(
+            semantic_results_from_rows(
+                query=query,
+                rows=dense_retrieval.search_similar(
+                    query_vec,
+                    document_frame,
+                    "case_local",
+                    top_k,
+                ),
+                source_type=None,
+            )
+        )
+    return results
+
+
+def vectorize_text(text: str, token_index: dict[str, int]) -> np.ndarray:
+    vector = np.zeros(len(token_index), dtype=np.float32)
+    for token in tokenize(text):
+        if token in token_index:
+            vector[token_index[token]] += 1.0
+    return vector
+
+
+def semantic_results_from_rows(
+    *,
+    query: dict[str, Any],
+    rows: Any,
+    source_type: str | None,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for rank, (_, row) in enumerate(rows.iterrows(), 1):
+        row_dict = row.to_dict() if hasattr(row, "to_dict") else dict(row)
+        similarity = round(float(row_dict.get("similarity", 0.0)), 6)
+        result_source_type = source_type or str(row_dict.get("source_type", "document"))
+        document_text = semantic_document_text(row_dict)
+        metadata = {
+            key: value
+            for key, value in row_dict.items()
+            if key
+            not in {
+                "_vec",
+                "similarity",
+                "document_body",
+                "document_text",
+                "search_text",
+            }
+        }
+        # Project precedent retrieval rows expose case_number directly.
+        # Store it in the same nested shape used by the metric matcher.
+        if result_source_type == "precedent" and row_dict.get("case_number"):
+            metadata.setdefault("case_law", {})["case_number"] = row_dict["case_number"]
+        results.append(
+            {
+                "clause_index": query["clause_index"],
+                "clause": query["clause"],
+                "result_id": semantic_result_id(row_dict, result_source_type),
+                "source_type": result_source_type,
+                "score": similarity,
+                "semantic_score": similarity,
+                "similarity": similarity,
+                "retrieval_method": "semantic",
+                "rank": rank,
+                "document_body": row_dict.get("document_body", document_text),
+                "document_text": row_dict.get("document_text", document_text),
+                "metadata": metadata,
+            }
+        )
+    return results
+
+
+def semantic_result_id(row: dict[str, Any], source_type: str) -> str:
+    if source_type == "law" and row.get("clause_key"):
+        return f"law:{row['clause_key']}"
+    if source_type == "precedent":
+        case_number = row.get("case_number")
+        if not case_number and isinstance(row.get("case_law"), dict):
+            case_number = row["case_law"].get("case_number")
+        if case_number:
+            return f"precedent:{case_number}"
+        if row.get("case_id"):
+            return f"precedent:{row['case_id']}"
+    return str(row.get("result_id") or f"{source_type}:{abs(hash(str(row)))}")
+
+
+def run_project_reranking(
+    *,
+    keyword_results: list[dict[str, Any]],
+    semantic_results: list[dict[str, Any]],
+    top_k: int = 20,
+) -> list[dict[str, Any]]:
+    """Use the project RRF reranker with the in-memory evaluation candidates."""
+    result_lookup: dict[tuple[int, str], dict[str, Any]] = {}
+    bm25_map: dict[int, dict[str, Any]] = {}
+    dense_map: dict[str, list[dict[str, Any]]] = {}
+
+    for result in keyword_results:
+        clause_index = int(result["clause_index"])
+        result_id = str(result["result_id"])
+        result_lookup.setdefault((clause_index, result_id), dict(result))
+        bm25_item = bm25_map.setdefault(
+            clause_index,
+            {"special_terms": result["clause"], "rank_map": {}},
+        )
+        bm25_item["rank_map"][result_id] = int(result["rank"])
+
+    for result in semantic_results:
+        clause_index = int(result["clause_index"])
+        result_id = str(result["result_id"])
+        lookup_item = result_lookup.setdefault((clause_index, result_id), dict(result))
+        lookup_item["semantic_score"] = result.get("semantic_score", result.get("score", 0.0))
+        bm25_map.setdefault(
+            clause_index,
+            {"special_terms": result["clause"], "rank_map": {}},
+        )
+        dense_map.setdefault(result["clause"], []).append(
+            {
+                "doc_id": result_id,
+                "score": float(result.get("score", result.get("similarity", 0.0))),
+                "rank": int(result["rank"]),
+                "doc_text": result.get("document_body") or result.get("document_text", ""),
+                "summary": result.get("metadata", {}).get("judgment_summary", ""),
+            }
+        )
+
+    reranked_groups = project_reranker.run_rrf(
+        bm25_map,
+        dense_map,
+        project_reranker.K,
+        top_k,
+    )
+    reranked_results: list[dict[str, Any]] = []
+    for group in reranked_groups:
+        clause_index = int(group["index"])
+        for match in group.get("top_matches", []):
+            result_id = str(match["doc_id"])
+            original = result_lookup.get((clause_index, result_id), {})
+            # Preserve the retrieval fields used by metric matching and reports.
+            item = {
+                "clause_index": clause_index,
+                "clause": group["special_terms"],
+                "result_id": result_id,
+                "source_type": original.get("source_type", "document"),
+                "document_body": original.get("document_body", match.get("doc_text", "")),
+                "document_text": original.get("document_text", match.get("doc_text", "")),
+                "metadata": original.get("metadata", {}),
+                "keyword_rank": match.get("bm25_rank"),
+                "semantic_rank": match.get("dense_rank"),
+                "keyword_score": float(original.get("keyword_score", 0.0)),
+                "semantic_score": float(original.get("semantic_score", 0.0)),
+                "rerank_score": float(match["rrf_score"]),
+                "score": float(match["rrf_score"]),
+                "retrieval_method": "rerank",
+                "rank": int(match["rank"]),
+            }
+            reranked_results.append(item)
+    return reranked_results
+
+
+def semantic_document_text(row: dict[str, Any]) -> str:
+    for field in ("child_text", "judgment_summary", "document_text", "document_body", "text"):
+        value = row.get(field)
+        if isinstance(value, str) and value.strip():
+            return value
+    return " ".join(str(value) for value in row.values() if value is not None)
+
+
 def current_stage_output_count(context: CaseExecutionContext, stage: str) -> int:
     if stage == "query_expansion":
         return len(context.expanded_queries)
@@ -259,6 +851,22 @@ def build_case_report(context: CaseExecutionContext) -> dict[str, Any]:
 def case_report_payload(context: CaseExecutionContext) -> dict[str, Any]:
     case = context.case
     clauses = list(case["clauses"])
+    stage_results = {
+        "bm25": context.keyword_results,
+        "semantic": context.semantic_results,
+        "rerank": context.reranked_results,
+    }
+    stage_recall_at_k = {
+        stage: calculate_stage_recall_at_k(
+            law_references=case["law_references"],
+            precedent_references=case["precedent_references"],
+            results=results,
+        )
+        for stage, results in stage_results.items()
+    }
+    candidate_counts = {
+        stage: count_source_candidates(results) for stage, results in stage_results.items()
+    }
     recall_by_k = calculate_recall_by_k(
         law_references=case["law_references"],
         precedent_references=case["precedent_references"],
@@ -308,6 +916,8 @@ def case_report_payload(context: CaseExecutionContext) -> dict[str, Any]:
         "reranked_results": context.reranked_results,
         "inspected_documents": context.inspected_documents,
         "stage_trace": context.stage_trace,
+        "candidate_counts": candidate_counts,
+        "stage_recall_at_k": stage_recall_at_k,
         "recall_by_k": recall_by_k,
         "law_recall_at_k": law_recall_at_k,
         "precedent_hit_flags_by_k": precedent_hit_flags_by_k,
@@ -317,6 +927,8 @@ def case_report_payload(context: CaseExecutionContext) -> dict[str, Any]:
             "case_id": context.case_id,
             "query_expansion": query_expansion,
             "expanded_queries": context.expanded_queries,
+            "candidate_counts": candidate_counts,
+            "stage_recall_at_k": stage_recall_at_k,
             "recall_by_k": recall_by_k,
             "law_recall_at_k": law_recall_at_k,
             "precedent_hit_flags_by_k": precedent_hit_flags_by_k,
@@ -424,6 +1036,8 @@ def build_run_report(
     law_recall_at_k = calculate_run_law_recall_at_k(micro_recall)
     query_recall_by_k = calculate_query_recall_by_k(case_reports)
     query_macro_recall_by_k = calculate_query_macro_recall_by_k(case_reports)
+    stage_recall_at_k = calculate_run_stage_recall_at_k(case_reports)
+    candidate_counts = calculate_run_candidate_counts(case_reports)
 
     report = {
         "schema_version": REPORT_SCHEMA_VERSION,
@@ -440,6 +1054,8 @@ def build_run_report(
             "law_recall_at_k": law_recall_at_k,
             "query_recall_by_k": query_recall_by_k,
             "query_macro_recall_by_k": query_macro_recall_by_k,
+            "stage_recall_at_k": stage_recall_at_k,
+            "candidate_counts": candidate_counts,
         },
         "input_path": str(input_path),
         "case_id": requested_case_id,
@@ -453,6 +1069,8 @@ def build_run_report(
         "law_recall_at_k": law_recall_at_k,
         "query_recall_by_k": query_recall_by_k,
         "query_macro_recall_by_k": query_macro_recall_by_k,
+        "stage_recall_at_k": stage_recall_at_k,
+        "candidate_counts": candidate_counts,
     }
     return report
 
@@ -552,6 +1170,37 @@ def calculate_law_recall_at_k(
         }
 
     return metrics
+
+
+def calculate_stage_recall_at_k(
+    *,
+    law_references: list[dict[str, Any]],
+    precedent_references: list[dict[str, Any]],
+    results: list[dict[str, Any]],
+) -> dict[str, dict[str, float | int]]:
+    metrics = calculate_recall_by_k(
+        law_references=law_references,
+        precedent_references=precedent_references,
+        reranked_results=results,
+    )
+    for values in metrics.values():
+        hits = int(values["law_hits"]) + int(values["precedent_hits"])
+        total = int(values["law_total"]) + int(values["precedent_total"])
+        values["hits"] = hits
+        values["total"] = total
+        values["integrated"] = ratio(hits, total)
+    return metrics
+
+
+def count_source_candidates(results: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {"law": 0, "precedent": 0, "total": 0}
+    for result in results:
+        source_type = result.get("source_type")
+        if source_type not in {"law", "precedent"}:
+            continue
+        counts[source_type] += 1
+        counts["total"] += 1
+    return counts
 
 
 def calculate_precedent_hit_flags_by_k(
@@ -809,6 +1458,83 @@ def calculate_run_law_recall_at_k(
     }
 
 
+def calculate_run_stage_recall_at_k(
+    case_reports: list[dict[str, Any]],
+) -> dict[str, dict[str, dict[str, float | int]]]:
+    return {
+        stage: calculate_stage_micro_recall(case_reports, stage)
+        for stage in ("bm25", "semantic", "rerank")
+    }
+
+
+def calculate_stage_micro_recall(
+    case_reports: list[dict[str, Any]],
+    stage: str,
+) -> dict[str, dict[str, float | int]]:
+    metrics: dict[str, dict[str, float | int]] = {}
+    for k in DEFAULT_RECALL_K_VALUES:
+        k_key = str(k)
+        law_hits = sum(
+            case.get("stage_recall_at_k", {})
+            .get(stage, {})
+            .get(k_key, {})
+            .get("law_hits", 0)
+            for case in case_reports
+        )
+        law_total = sum(
+            case.get("stage_recall_at_k", {})
+            .get(stage, {})
+            .get(k_key, {})
+            .get("law_total", 0)
+            for case in case_reports
+        )
+        precedent_hits = sum(
+            case.get("stage_recall_at_k", {})
+            .get(stage, {})
+            .get(k_key, {})
+            .get("precedent_hits", 0)
+            for case in case_reports
+        )
+        precedent_total = sum(
+            case.get("stage_recall_at_k", {})
+            .get(stage, {})
+            .get(k_key, {})
+            .get("precedent_total", 0)
+            for case in case_reports
+        )
+        hits = law_hits + precedent_hits
+        total = law_total + precedent_total
+        metrics[k_key] = {
+            "law": ratio(law_hits, law_total),
+            "law_hits": law_hits,
+            "law_total": law_total,
+            "precedent": ratio(precedent_hits, precedent_total),
+            "precedent_hits": precedent_hits,
+            "precedent_total": precedent_total,
+            "integrated": ratio(hits, total),
+            "hits": hits,
+            "total": total,
+        }
+    return metrics
+
+
+def calculate_run_candidate_counts(
+    case_reports: list[dict[str, Any]],
+) -> dict[str, dict[str, int]]:
+    totals = {
+        stage: {"law": 0, "precedent": 0, "total": 0}
+        for stage in ("bm25", "semantic", "rerank")
+    }
+    for case in case_reports:
+        for stage, counts in case.get("candidate_counts", {}).items():
+            if stage not in totals:
+                continue
+            totals[stage]["law"] += counts.get("law", 0)
+            totals[stage]["precedent"] += counts.get("precedent", 0)
+            totals[stage]["total"] += counts.get("total", 0)
+    return totals
+
+
 def calculate_query_recall_by_k(
     case_reports: list[dict[str, Any]],
 ) -> dict[str, dict[str, float | int]]:
@@ -916,32 +1642,29 @@ def count_precedent_hits(
 
 
 def law_match_values(result: dict[str, Any]) -> list[Any]:
-    values = [
-        result.get("clause_key"),
-        result.get("article_key"),
-        result.get("law_name"),
-    ]
+    if result.get("source_type") != "law":
+        return []
+    values = [result.get("clause_key")]
     metadata = result.get("metadata")
     if isinstance(metadata, dict):
-        values.extend(
-            [
-                metadata.get("clause_key"),
-                metadata.get("article_key"),
-                metadata.get("law_name"),
-            ]
-        )
+        values.append(metadata.get("clause_key"))
     return values
 
 
 def precedent_match_values(result: dict[str, Any]) -> list[Any]:
     """Return retrieved precedent identifiers eligible for validation matching."""
+    if result.get("source_type") != "precedent":
+        return []
+    values = [result.get("case_number")]
     metadata = result.get("metadata")
     if not isinstance(metadata, dict):
-        return []
+        return values
+    # Case recall is exact-match only on case_number, whether flat or nested.
+    values.append(metadata.get("case_number"))
     case_law = metadata.get("case_law")
     if isinstance(case_law, dict):
-        return [case_law.get("case_number")]
-    return []
+        values.append(case_law.get("case_number"))
+    return values
 
 
 def normalize_match_value(value: Any) -> str:
@@ -991,6 +1714,7 @@ def run(
     case_id: str | None = None,
     output_path: Path | None = None,
 ) -> Path:
+    assert_real_pipeline_imports_available()
     dataset = load_dataset(input_path)
     cases = select_cases(dataset, case_id)
     report = build_report(input_path=input_path, cases=cases, case_id=case_id)
@@ -1084,6 +1808,51 @@ def format_dataset_recall_summary_console_lines(report: dict[str, Any]) -> list[
     return lines
 
 
+def format_stage_recall_console_lines(report: dict[str, Any]) -> list[str]:
+    metrics = report.get("metrics", {})
+    stage_recall = metrics.get("stage_recall_at_k", {})
+    candidate_counts = metrics.get("candidate_counts", {})
+    lines: list[str] = []
+    for stage in ("bm25", "semantic", "rerank"):
+        counts = candidate_counts.get(stage, {})
+        for k in (3, 5, 10):
+            values = stage_recall.get(stage, {}).get(str(k), {})
+            lines.append(
+                (
+                    f"stage_recall stage={stage} recall@{k} "
+                    f"law={values.get('law', 0.0):.6f} "
+                    f"precedent={values.get('precedent', 0.0):.6f} "
+                    f"integrated={values.get('integrated', 0.0):.6f} "
+                    f"candidates={counts.get('total', 0)} "
+                    f"law_candidates={counts.get('law', 0)} "
+                    f"precedent_candidates={counts.get('precedent', 0)}"
+                )
+            )
+            if stage == "semantic":
+                lines.append(
+                    (
+                        f"semantic_retrieval_recall@{k} "
+                        f"law={values.get('law', 0.0):.6f} "
+                        f"precedent={values.get('precedent', 0.0):.6f} "
+                        f"integrated={values.get('integrated', 0.0):.6f} "
+                        f"hits={values.get('hits', 0)} "
+                        f"total={values.get('total', 0)}"
+                    )
+                )
+            if stage == "rerank":
+                lines.append(
+                    (
+                        f"rerank_recall@{k} "
+                        f"law={values.get('law', 0.0):.6f} "
+                        f"precedent={values.get('precedent', 0.0):.6f} "
+                        f"integrated={values.get('integrated', 0.0):.6f} "
+                        f"hits={values.get('hits', 0)} "
+                        f"total={values.get('total', 0)}"
+                    )
+                )
+    return lines
+
+
 def main() -> int:
     args = parse_args()
     input_path = Path(args.input)
@@ -1095,6 +1864,9 @@ def main() -> int:
             case_id=args.case_id,
             output_path=output_path,
         )
+    except PipelineImportError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
     except DatasetValidationError as error:
         print(f"error: {error}", file=sys.stderr)
         return 2
@@ -1105,6 +1877,8 @@ def main() -> int:
     if report["case_id"] is not None:
         print(f"case_id={report['case_id']}")
     for line in format_dataset_recall_summary_console_lines(report):
+        print(line)
+    for line in format_stage_recall_console_lines(report):
         print(line)
     for line in format_recall_at_k_console_lines(report):
         print(line)

--- a/evaluation/legal_retrieval_eval.py
+++ b/evaluation/legal_retrieval_eval.py
@@ -8,6 +8,7 @@ import json
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -572,6 +573,22 @@ def run_bm25_retrieval(
     return results
 
 
+@lru_cache(maxsize=1)
+def load_semantic_chunks() -> tuple[pd.DataFrame, pd.DataFrame]:
+    return (
+        dense_retrieval.load_chunks(
+            dense_retrieval.LAW_TABLE,
+            LAW_SEMANTIC_EMBED_COL,
+            LAW_SEMANTIC_KEEP_COLS,
+        ),
+        dense_retrieval.load_chunks(
+            dense_retrieval.PREC_TABLE,
+            PRECEDENT_SEMANTIC_EMBED_COL,
+            PRECEDENT_SEMANTIC_KEEP_COLS,
+        ),
+    )
+
+
 def run_semantic_retrieval(
     *,
     expanded_queries: list[dict[str, Any]],
@@ -590,16 +607,7 @@ def run_semantic_retrieval(
     if case is not None and not is_real_eval_case(case):
         return []
 
-    law_chunks = dense_retrieval.load_chunks(
-        dense_retrieval.LAW_TABLE,
-        LAW_SEMANTIC_EMBED_COL,
-        LAW_SEMANTIC_KEEP_COLS,
-    )
-    precedent_chunks = dense_retrieval.load_chunks(
-        dense_retrieval.PREC_TABLE,
-        PRECEDENT_SEMANTIC_EMBED_COL,
-        PRECEDENT_SEMANTIC_KEEP_COLS,
-    )
+    law_chunks, precedent_chunks = load_semantic_chunks()
 
     results: list[dict[str, Any]] = []
     for query in expanded_queries:

--- a/pipeline/reranking/reranker.py
+++ b/pipeline/reranking/reranker.py
@@ -187,7 +187,15 @@ def run_rrf(bm25_map: dict, dense_map: dict, k: int, top_n: int) -> list:
                 "summary"    : summary,
             })
 
-        scored.sort(key=lambda x: x["rrf_score"], reverse=True)
+        # Equal RRF scores are common in small eval sets, so keep output stable.
+        scored.sort(
+            key=lambda x: (
+                -x["rrf_score"],
+                x["bm25_rank"] if x["bm25_rank"] is not None else 1000,
+                x["dense_rank"] if x["dense_rank"] is not None else 1000,
+                x["doc_id"],
+            )
+        )
         top = scored[:top_n]
 
         for rank, item in enumerate(top, 1):

--- a/scripts/load_data_cloud_sql.py
+++ b/scripts/load_data_cloud_sql.py
@@ -630,7 +630,12 @@ def clause_key_for(
     article_key = article_key_for(law_name, article_no)
     if paragraph_no:
         return f"{article_key}_제{paragraph_no}항"
-    return f"{article_key}_조문"
+    return article_key
+
+
+def normalize_reference_clause_key(clause_key: str) -> str:
+    """DB reference keys must match law_child/law_parent keys exactly."""
+    return clause_key.removesuffix("_조문")
 
 
 def article_no_from_match(match: re.Match[str]) -> str:
@@ -686,7 +691,9 @@ def parse_referenced_law_text(
 
         article_no = article_no_from_match(match)
         paragraph_no = match.group("paragraph_no")
-        clause_key = clause_key_for(law_name, article_no, paragraph_no)
+        clause_key = normalize_reference_clause_key(
+            clause_key_for(law_name, article_no, paragraph_no)
+        )
         unique_key = (case_id, clause_key)
         if unique_key in seen:
             continue

--- a/shared/llm/gemini_client.py
+++ b/shared/llm/gemini_client.py
@@ -134,6 +134,7 @@ class GeminiClient:
         model: str | None = None,
         system_instruction: str | None = None,
         response_schema: type | None = None,
+        temperature: float | None = None,
     ) -> Any:
         """텍스트 또는 파일을 입력받아 생성 결과를 반환한다.
 
@@ -151,6 +152,8 @@ class GeminiClient:
             Pydantic ``BaseModel`` 서브클래스. 전달 시 구조화 JSON 출력을
             요청하고 ``response.parsed`` (Pydantic 인스턴스)를 반환한다.
             None이면 ``response.text`` (str)를 반환한다.
+        temperature:
+            생성 온도. None이면 모델 기본값을 사용한다.
 
         Raises
         ------
@@ -165,6 +168,8 @@ class GeminiClient:
         if response_schema is not None:
             config_kwargs["response_mime_type"] = "application/json"
             config_kwargs["response_schema"] = response_schema
+        if temperature is not None:
+            config_kwargs["temperature"] = temperature
 
         config = types.GenerateContentConfig(**config_kwargs) if config_kwargs else None
 


### PR DESCRIPTION
## 변경 사항
- `data/processors/validation_dataset_processor.py`를 추가해 Cloud SQL export 기반 평가셋 생성 흐름을 구현했습니다.
- QA 데이터는 `question_id` 기준으로 묶고, 여러 답변의 GT 법령/판례를 합집합으로 저장하도록 했습니다.
- case-law와 QA 모두 `특약` 또는 `조항` 후보만 사용하고, Gemini stage1/stage2로 평가 가능한 조항만 남기도록 했습니다.
- LLM 호출은 `shared.llm.gemini_client`를 사용하도록 연결했습니다.
- 5개 QA, 5개 case-law 샘플 리뷰 gate와 checkpoint 재시작 처리를 추가했습니다.
- case-law `gt_laws`와 Cloud SQL 업로드 단계에서 `_조문` suffix가 남지 않도록 정규화했습니다.
- `evaluation/legal_retrieval_eval.py`에서 `evaluation/eval_set.json`을 읽어 실제 retrieval/reranking pipeline으로 평가하도록 했습니다.
- `bm25`, `semantic`, `rerank` 단계별 recall@3/5/10을 exact match로 출력합니다.
- threshold 없이 JSON report와 콘솔 요약만 출력합니다.
- `--case-id`로 특정 평가 데이터만 디버깅할 수 있게 했습니다.

## 관련 이슈
closes #70

## 스크린샷 (선택)
| Before | After |
|--------|-------|
| 팀원별 retrieval 수정 결과를 같은 기준으로 비교하기 어려웠습니다. | 같은 `evaluation/eval_set.json`으로 단계별 recall@3/5/10 report를 출력할 수 있습니다. |

## 테스트
- [ ] `python data/processors/validation_dataset_processor.py --help`
- [ ] `python evaluation/legal_retrieval_eval.py --input "$(pwd)/evaluation/eval_set.json" --output baseline.json`

## 실행 방법
평가셋 생성:

```bash
python data/processors/validation_dataset_processor.py
```

위 명령은 먼저 `evaluation/stage1_review_samples.json`을 만들고 종료합니다. 샘플 검수 후 전체 생성:

```bash
python data/processors/validation_dataset_processor.py --sample-review-approved
```

평가 실행:

```bash
python evaluation/legal_retrieval_eval.py \
  --input "$(pwd)/evaluation/eval_set.json" \
  --output baseline.json
```

특정 데이터만 확인:

```bash
python evaluation/legal_retrieval_eval.py \
  --input "$(pwd)/evaluation/eval_set.json" \
  --case-id case_103168 \
  --output debug-case-103168.json
```

## 체크리스트
- [ ] 코드가 정상적으로 동작합니다.
- [ ] 커밋 메시지가 컨벤션을 따릅니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 추가/수정했습니다.
- [ ] 문서를 업데이트했습니다.
- [ ] `evaluation/results/*.json`을 commit하지 않았습니다.
- [ ] `evaluation/eval_set_checkpoint.json`을 commit하지 않았습니다.
- [ ] `evaluation/eval_set.json` 포함 여부를 팀과 확인했습니다.

## 리뷰어에게
- `gt_laws`와 검색 결과 법령 key가 같은 형식으로 비교되는지 확인 부탁드립니다.
- `gt_cases`는 판례번호 exact match 기준이 맞는지 확인 부탁드립니다.
- `validation_dataset_processor.py`의 LLM stage1/stage2 흐름과 sample review gate가 팀 작업 방식에 맞는지 봐주세요.
- 실행 결과 JSON은 파일이 커질 수 있어서 PR에는 포함하지 않았습니다.
