### PR TITLE
[fix]Refactor/44-query-expansion

### DIFF
--- a/evaluation/legal_retrieval_eval.py
+++ b/evaluation/legal_retrieval_eval.py
@@ -433,6 +433,12 @@ def parse_args() -> argparse.Namespace:
             "embed_kure uses law_child.embed_kure and case_law.embedding_kure."
         ),
     )
+    parser.add_argument(
+        "--use-llm-qe",
+        action="store_true",
+        default=False,
+        help="Use actual LLM (Gemini) for query expansion instead of the deterministic stub.",
+    )
     return parser.parse_args()
 
 
@@ -1378,6 +1384,7 @@ def build_report(
     expand_fn=None,
     semantic_embed_cols: str | list[str] | tuple[str, ...] | None = None,
     semantic_embed_col: str | None = None,
+    expand_fn=None,
 ) -> dict[str, Any]:
     selected_embed_cols = normalize_semantic_embed_cols(
         semantic_embed_cols,
@@ -2242,6 +2249,7 @@ def run(
     use_llm_qe: bool = False,
     semantic_embed_cols: str | list[str] | tuple[str, ...] | None = None,
     semantic_embed_col: str | None = None,
+    use_llm_qe: bool = False,
 ) -> Path:
     assert_real_pipeline_imports_available()
     expand_fn = expand_case_queries_with_llm if use_llm_qe else expand_case_queries
@@ -2256,6 +2264,7 @@ def run(
         case_id=case_id,
         semantic_embed_cols=semantic_embed_cols,
         semantic_embed_col=semantic_embed_col,
+        expand_fn=expand_fn,
     )
     report_path = save_report(report, output_path=output_path)
     log_progress(f"report_saved path={report_path}")
@@ -2480,6 +2489,7 @@ def main() -> int:
             output_path=output_path,
             use_llm_qe=args.use_llm_qe,
             semantic_embed_cols=args.semantic_embed_cols,
+            use_llm_qe=args.use_llm_qe,
         )
     except PipelineImportError as error:
         print(f"error: {error}", file=sys.stderr)

--- a/evaluation/legal_retrieval_eval.py
+++ b/evaluation/legal_retrieval_eval.py
@@ -420,10 +420,6 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--use-llm-qe",
-        action="store_true",
-        default=False,
-        help="Use actual LLM (Gemini) for query expansion instead of the deterministic stub.",
         "--semantic-embed-cols",
         default=DEFAULT_SEMANTIC_EMBED_COLS_ARG,
         help=(
@@ -1384,7 +1380,6 @@ def build_report(
     expand_fn=None,
     semantic_embed_cols: str | list[str] | tuple[str, ...] | None = None,
     semantic_embed_col: str | None = None,
-    expand_fn=None,
 ) -> dict[str, Any]:
     selected_embed_cols = normalize_semantic_embed_cols(
         semantic_embed_cols,
@@ -2249,7 +2244,6 @@ def run(
     use_llm_qe: bool = False,
     semantic_embed_cols: str | list[str] | tuple[str, ...] | None = None,
     semantic_embed_col: str | None = None,
-    use_llm_qe: bool = False,
 ) -> Path:
     assert_real_pipeline_imports_available()
     expand_fn = expand_case_queries_with_llm if use_llm_qe else expand_case_queries
@@ -2257,14 +2251,13 @@ def run(
     log_progress(f"dataset_loaded input_path={input_path} cases={len(dataset)}")
     cases = select_cases(dataset, case_id)
     log_progress(f"dataset_selected cases={len(cases)} case_id={case_id or 'all'}")
-    report = build_report(input_path=input_path, cases=cases, case_id=case_id, expand_fn=expand_fn)
     report = build_report(
         input_path=input_path,
         cases=cases,
         case_id=case_id,
+        expand_fn=expand_fn,
         semantic_embed_cols=semantic_embed_cols,
         semantic_embed_col=semantic_embed_col,
-        expand_fn=expand_fn,
     )
     report_path = save_report(report, output_path=output_path)
     log_progress(f"report_saved path={report_path}")
@@ -2489,7 +2482,6 @@ def main() -> int:
             output_path=output_path,
             use_llm_qe=args.use_llm_qe,
             semantic_embed_cols=args.semantic_embed_cols,
-            use_llm_qe=args.use_llm_qe,
         )
     except PipelineImportError as error:
         print(f"error: {error}", file=sys.stderr)

--- a/evaluation/legal_retrieval_eval.py
+++ b/evaluation/legal_retrieval_eval.py
@@ -38,9 +38,12 @@ try:
     from pipeline.retrieval.evaluation_retrieval import (
         collect_case_documents,
         expand_case_queries,
-        expand_case_queries_with_llm,
         inspect_retrieved_documents,
     )
+    try:
+        from pipeline.retrieval.evaluation_retrieval import expand_case_queries_with_llm
+    except ImportError:
+        expand_case_queries_with_llm = None  # type: ignore[assignment]
     from rank_bm25 import BM25Okapi
 except ImportError as error:
     PIPELINE_IMPORT_ERROR = error
@@ -2246,6 +2249,11 @@ def run(
     semantic_embed_col: str | None = None,
 ) -> Path:
     assert_real_pipeline_imports_available()
+    if use_llm_qe and expand_case_queries_with_llm is None:
+        raise PipelineImportError(
+            "--use-llm-qe requires expand_case_queries_with_llm. "
+            "evaluation_retrieval.py를 최신 버전으로 업데이트하세요."
+        )
     expand_fn = expand_case_queries_with_llm if use_llm_qe else expand_case_queries
     dataset = load_dataset(input_path)
     log_progress(f"dataset_loaded input_path={input_path} cases={len(dataset)}")


### PR DESCRIPTION
## 📝 변경 사항
QE(Query Expansion)를 4섹션 형식에서 산문형으로 전면 개편. 서로 다른 특약이 확장 후 동일한 형태로 수렴되는 일반화 문제를 해결.

- query_expansion_prompt.py: 4섹션 형식 제거, 특약 원문 보존 원칙(SPECIFICITY_ANCHOR_GUIDE) 및 특약 특화 키워드 원칙(CLAUSE_SPECIFIC_TERMS_GUIDE) 추가
- query_expansion_schema.py: expansion_query max_length 700→300, - keywords max_length 15→5, 섹션 검증 로직 제거
- query_expansion.py: repair prompt를 새 형식에 맞게 수정
- evaluation_retrieval.py: 스키마 변경에 따른 stub 업데이트, expand_case_queries_with_llm() 추가
- legal_retrieval_eval.py: --use-llm-qe 플래그 추가

## 🔗 관련 이슈
<!-- 관련 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
closes #

## 📸 스크린샷 (선택)
`eval_set.json` 349개 케이스 전수 평가 완료 (349/349)

| 지표 (Metric) | 변경 전 | 변경 후 (LLM QE) |
| :--- | :---: | :---: |
| macro recall@5 integrated | 0.0964 | **0.1650** |
| macro recall@20 integrated | 0.1609 | **0.2577** |
| BM25@5 law | 0.0000 | **0.1758** |

## 🧪 테스트
<!-- 어떻게 테스트했는지 설명해주세요. -->
-

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작합니다.
- [ ] 스키마 변경이 RAG 파이프라인 입력 구조에 영향 없음 (retrieval_payload 동일)
- [ ]  eval 349/349 완료 (기존 30개 실패 해소)
- [ ] --use-llm-qe 미사용 시 기존 stub 동작 유지

## 💬 리뷰어에게
RAG 파이프라인(BM25/Semantic/RRF) 자체는 변경 없음. QE 출력 포맷(dense_query, bm25_keywords)이 동일하게 유지되므로 하위 호환성 문제 없음. rerank < 단계별 단독 성능 현상은 RRF 파트 이슈로 이번 PR 범위 밖.