### PR TITLE
[Refactor] case_law 임베딩 컬럼명 통일 (embedding → embed_vertex) (#78)

### DIFF
--- a/evaluation/legal_retrieval_eval.py
+++ b/evaluation/legal_retrieval_eval.py
@@ -61,12 +61,12 @@ SEMANTIC_EMBED_CONFIGS = {
     "embed_vertex": {
         "query_embed_col": "embed_vertex",
         "law_embed_col": "embed_vertex",
-        "precedent_embed_col": "embedding",
+        "precedent_embed_col": "embed_vertex",
     },
     "embed_kure": {
         "query_embed_col": "embed_kure",
         "law_embed_col": "embed_kure",
-        "precedent_embed_col": "embedding_kure",
+        "precedent_embed_col": "embed_kure",
     },
 }
 DEFAULT_SEMANTIC_EMBED_COLS = tuple(SEMANTIC_EMBED_CONFIGS)
@@ -428,8 +428,8 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Comma-separated semantic embedding profiles to evaluate. "
             "Default evaluates both embed_vertex and embed_kure. "
-            "embed_vertex uses law_child.embed_vertex and case_law.embedding; "
-            "embed_kure uses law_child.embed_kure and case_law.embedding_kure."
+            "embed_vertex uses law_child.embed_vertex and case_law.embed_vertex; "
+            "embed_kure uses law_child.embed_kure and case_law.embed_kure."
         ),
     )
     parser.add_argument(

--- a/infra/cloud_sql/init_schema.sql
+++ b/infra/cloud_sql/init_schema.sql
@@ -56,8 +56,8 @@ CREATE TABLE IF NOT EXISTS case_law (
     referenced_law TEXT,
     referenced_case TEXT,
     case_detail TEXT,
-    embedding vector(3072),
-    embedding_kure vector(1024)
+    embed_vertex vector(3072),
+    embed_kure vector(1024)
 );
 
 ALTER TABLE law_child
@@ -67,10 +67,10 @@ ALTER TABLE law_child
     ADD COLUMN IF NOT EXISTS embed_kure vector(1024);
 
 ALTER TABLE case_law
-    ADD COLUMN IF NOT EXISTS embedding vector(3072);
+    ADD COLUMN IF NOT EXISTS embed_vertex vector(3072);
 
 ALTER TABLE case_law
-    ADD COLUMN IF NOT EXISTS embedding_kure vector(1024);
+    ADD COLUMN IF NOT EXISTS embed_kure vector(1024);
 
 CREATE INDEX IF NOT EXISTS idx_case_law_case_number
     ON case_law (case_number);

--- a/scripts/load_data_cloud_sql.py
+++ b/scripts/load_data_cloud_sql.py
@@ -121,8 +121,8 @@ CASE_LAW_DB_COLUMNS = [
     "referenced_law",
     "referenced_case",
     "case_detail",
-    "embedding",
-    "embedding_kure",
+    "embed_vertex",
+    "embed_kure",
 ]
 
 REFERENCED_LAW_DB_COLUMNS = [
@@ -551,8 +551,8 @@ def map_case_law_row(row: dict[str, str]) -> dict[str, Any]:
         "referenced_law": to_nullable_text(row["referenced_law"]),
         "referenced_case": to_nullable_text(row["referenced_case"]),
         "case_detail": to_nullable_text(row["case_detail"]),
-        "embedding": parse_pgvector(row["embed_vertex"]),
-        "embedding_kure": parse_pgvector(
+        "embed_vertex": parse_pgvector(row["embed_vertex"]),
+        "embed_kure": parse_pgvector(
             row["embed_kure"],
             expected_dimensions=1024,
         ),


### PR DESCRIPTION
## 📝 변경 사항

- `case_law` 테이블의 임베딩 컬럼명을 `law_child` 테이블과 일치하도록 통일했습니다.
  - `embedding` → `embed_vertex`
  - `embedding_kure` → `embed_kure`
- `infra/cloud_sql/init_schema.sql`: CREATE TABLE 및 ALTER TABLE 구문에 새 컬럼명 반영
- `scripts/load_data_cloud_sql.py`: `CASE_LAW_DB_COLUMNS` 리스트 및 `map_case_law_row()` 키 수정
- `evaluation/legal_retrieval_eval.py`: `SEMANTIC_EMBED_CONFIGS`의 `precedent_embed_col` 값 수정

## 🔗 관련 이슈

closes #78 

## 📸 스크린샷 (선택)

| Before | After |
|--------|-------|
| `case_law.embedding`, `case_law.embedding_kure` | `case_law.embed_vertex`, `case_law.embed_kure` |
| `SEMANTIC_EMBED_CONFIGS`에서 law/precedent 컬럼명이 달랐음 | 두 테이블 모두 동일한 컬럼명 사용 |

## ⚠️ DB 마이그레이션 필요

이 PR 머지와 함께 아래 DDL을 Cloud SQL에 실행해야 합니다:

```sql
ALTER TABLE case_law RENAME COLUMN embedding TO embed_vertex;
ALTER TABLE case_law RENAME COLUMN embedding_kure TO embed_kure;
```

코드 배포와 DB 마이그레이션을 **동시에** 진행해야 컬럼 불일치가 발생하지 않습니다.

## 🧪 테스트

- `scripts/build_retrieve_val_results.py` 실행 시 `embed_vertex` 컬럼으로 벡터 검색 정상 동작 확인
- `evaluation/legal_retrieval_eval.py` 실행 시 `embed_vertex`/`embed_kure` 프로파일 정상 동작 확인
- `questions` 테이블의 `embedding` 컬럼은 변경되지 않았음을 확인

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게

- DB 마이그레이션 DDL 실행 타이밍을 코드 배포와 맞춰 주세요.
- `questions.embedding` 컬럼은 이번 변경 범위 밖임을 확인해 주세요.
- `pipeline/retrieval/dense_retrieval.py`의 `PREC_TABLE` 매핑 주석(line 75)은 이미 구 이름을 임시 매핑으로 표시하고 있어, 추후 정리가 필요합니다.
