### PR TITLE
[feature]86-QE-skip-로직

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ tests/pipeline/query_expansion_v1/
 # test
 tests/
 frontend/
+
+.log/

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,3 @@ tests/pipeline/query_expansion_v1/
 # test
 tests/
 frontend/
-
-.log/

--- a/evaluation/legal_retrieval_eval_multi.py
+++ b/evaluation/legal_retrieval_eval_multi.py
@@ -513,6 +513,16 @@ def parse_args() -> argparse.Namespace:
             "값이 높을수록 BM25 가중치가 커집니다."
         ),
     )
+    parser.add_argument(
+        "--qe-cache",
+        metavar="PATH",
+        default=None,
+        help=(
+            "이전 실행 결과 JSON 경로 (evaluation/results/ 아래 파일). "
+            "지정 시 Query Expansion LLM 호출을 스킵하고 캐시된 expanded_queries를 재사용합니다. "
+            "캐시에 없는 case_id는 LLM을 호출합니다."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -631,6 +641,34 @@ def build_case_contexts(
         )
         for index, case in enumerate(cases)
     ]
+
+
+# ── QE 캐시 ──────────────────────────────────────────────────────────────
+
+def load_qe_cache(path: Path) -> dict[str, list[dict[str, Any]]]:
+    """이전 실행 결과 JSON에서 case_id → expanded_queries 매핑을 로드한다."""
+    with path.open("r", encoding="utf-8") as f:
+        report = json.load(f)
+    cache: dict[str, list[dict[str, Any]]] = {}
+    for case_report in report.get("cases", []):
+        case_id = case_report.get("case_id")
+        expanded = case_report.get("expanded_queries")
+        if case_id and isinstance(expanded, list):
+            cache[case_id] = expanded
+    return cache
+
+
+def make_cached_expand_fn(cache: dict[str, list[dict[str, Any]]]):
+    """캐시에서 expanded_queries를 반환하는 expand_fn을 생성한다.
+    캐시에 없는 case_id는 LLM을 호출한다."""
+    def expand_fn(case: dict[str, Any]) -> list[dict[str, Any]]:
+        case_id = case.get("case_id", "")
+        if case_id in cache:
+            log_progress(f"qe_cache_hit case_id={case_id}")
+            return cache[case_id]
+        log_progress(f"qe_cache_miss case_id={case_id} falling_back_to_llm")
+        return expand_case_queries_with_llm(case)
+    return expand_fn
 
 
 # ── 파이프라인 실행 ───────────────────────────────────────────────────────
@@ -2576,9 +2614,15 @@ def run(
     case_workers: int = CASE_WORKERS,
     alpha_law: float = ALPHA_LAW,
     alpha_prec: float = ALPHA_PREC,
+    qe_cache_path: Path | None = None,
 ) -> Path:
     assert_real_pipeline_imports_available()
-    expand_fn = expand_case_queries_with_llm
+    if qe_cache_path is not None:
+        cache = load_qe_cache(qe_cache_path)
+        expand_fn = make_cached_expand_fn(cache)
+        log_progress(f"qe_cache_loaded path={qe_cache_path} entries={len(cache)}")
+    else:
+        expand_fn = expand_case_queries_with_llm
     dataset = load_dataset(input_path)
     log_progress(f"dataset_loaded input_path={input_path} cases={len(dataset)}")
     cases = select_cases(dataset, case_id)
@@ -2604,6 +2648,7 @@ def main() -> int:
     args = parse_args()
     input_path = Path(args.input)
     output_path = Path(args.output) if args.output else None
+    qe_cache_path = Path(args.qe_cache) if args.qe_cache else None
 
     try:
         report_path = run(
@@ -2614,6 +2659,7 @@ def main() -> int:
             case_workers=args.case_workers,
             alpha_law=args.alpha_law,
             alpha_prec=args.alpha_prec,
+            qe_cache_path=qe_cache_path,
         )
     except PipelineImportError as error:
         print(f"error: {error}", file=sys.stderr)

--- a/evaluation/legal_retrieval_eval_multi.py
+++ b/evaluation/legal_retrieval_eval_multi.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 import pandas as pd
@@ -658,7 +658,7 @@ def load_qe_cache(path: Path) -> dict[str, list[dict[str, Any]]]:
     return cache
 
 
-def make_cached_expand_fn(cache: dict[str, list[dict[str, Any]]]):
+def make_cached_expand_fn(cache: dict[str, list[dict[str, Any]]]) -> Callable[[dict[str, Any]], list[dict[str, Any]]]:
     """캐시에서 expanded_queries를 반환하는 expand_fn을 생성한다.
     캐시에 없는 case_id는 LLM을 호출한다."""
     def expand_fn(case: dict[str, Any]) -> list[dict[str, Any]]:


### PR DESCRIPTION
## 📝 변경 사항

- `evaluation/legal_retrieval_eval_multi.py`에 `--qe-cache` 옵션 추가
  - 이전 실행 결과 JSON을 넘기면 Query Expansion LLM 호출을 스킵하고 캐시된 `expanded_queries`를 재사용
  - 캐시에 없는 `case_id`는 자동으로 LLM을 호출하여 fallback 처리
  - `load_qe_cache()`, `make_cached_expand_fn()` 함수 추가
  - `run()` 함수에 `qe_cache_path: Path | None = None` 파라미터 추가 (기본값 None, 역호환성 유지)
- `.gitignore` 정리

## 🔗 관련 이슈

closes #86

## 🧪 테스트

349개 케이스(`eval_set.json`) 전수 실행으로 검증

| Before | After |
|--------|-------|
| 매 실행마다 Gemini LLM QE 호출 (349케이스, 612특약) | `--qe-cache` 지정 시 LLM 호출 0회 (`qe_cache_hit` 349건, `qe_cache_miss` 0건) |
| 실행 시간 **약 60분** | 실행 시간 **약 30분** (~50% 단축) |
| Recall@20 법령 0.2895 / 판례 0.4762 | Recall@20 법령 0.2895 / 판례 0.4762 (**동일**) |

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게

**첫 실행 (QE 결과 생성):**
```bash
python evaluation/legal_retrieval_eval_multi.py \
  --input "$(pwd)/evaluation/eval_set.json" \
  --output eval_results_with_qe.json \
  2>&1 | tee evaluation/run_with_qe.log #로그는 빼도됨
```
**이후 실행 (QE 스킵):**
위에서 나온 결과, 즉 제공하는 output json 파일을 --qe-cahe 뒤에 넣으면 됨.
```bash
python evaluation/legal_retrieval_eval_multi.py \
  --input "$(pwd)/evaluation/eval_set.json" \
  --output eval_results_skip_qe.json \
  --qe-cache evaluation/results/eval_results_with_qe.json \
  2>&1 | tee evaluation/run_skip_qe.log #로그는 빼도됨
```