### PR TITLE
feat(embeddig): vertex 모델로 단일화

### DIFF
--- a/data/processors/caselaw_embedder.py
+++ b/data/processors/caselaw_embedder.py
@@ -1,7 +1,7 @@
 """
-임베딩 통합 파이프라인: gemini-embedding-001 (Vertex AI) + KURE-v1 (로컬)
-- case_law.csv 읽어서 issue 컬럼을 두 모델로 임베딩
-- embed_vertex, embed_kure 컬럼을 JSON 문자열로 저장
+임베딩 통합 파이프라인: gemini-embedding-001 (Vertex AI)
+- case_law.csv 읽어서 judgment_summary 컬럼을 Vertex AI로 임베딩
+- embed_vertex 컬럼을 JSON 문자열로 저장
 - 체크포인트/재개 지원: 기존 출력 파일이 있으면 미완료 행만 처리
 - 인증: ADC (gcloud auth application-default login)
 - 설치: pip install google-genai sentence-transformers python-dotenv
@@ -22,42 +22,16 @@ INPUT_CSV   = _BASE / "output" / "case_law.csv"
 OUTPUT_FILE = _BASE / "output" / "case_law_with_embeddings.csv"
 
 VERTEX_MODEL = "gemini-embedding-001"
-KURE_MODEL   = "nlpai-lab/KURE-v1"
-E5_MODEL     = "intfloat/multilingual-e5-large"
-KOLEGAL_MODEL = "woong0322/ko-legal-sbert-finetuned"
-
-BATCH_SIZE   = 16          # KURE 배치 크기
 VERTEX_DIM   = 3072        # gemini-embedding-001 출력 차원
 SLEEP_SEC    = 0.1         # Vertex AI 호출 간격 (초)
 MAX_RETRIES  = 5
 RETRY_DELAY  = 10          # 재시도 기본 대기 (초)
 
-MAX_CHARS_VERTEX = 3000   # gemini-embedding-001: 2048토큰 × 1.5
-MAX_CHARS_KURE   = 768    # KURE-v1: 512토큰 × 1.5
-MAX_CHARS_E5     = 768
-
-# 임베딩 컬럼명
-COL_VERTEX   = "embed_vertex"
-COL_KURE     = "embed_kure"
-COL_E5       = "embed_e5"
-COL_KOLEGAL    = "embed_kolegal"
-
-COL_VERTEX_JS = "embed_vertex_js"
-COL_KURE_JS   = "embed_kure_js"
-COL_E5_JS     = "embed_e5_js"
-COL_KOLEGAL_JS = "embed_kolegal_js"
-
 
 # ── 인자 파싱 ──────────────────────────────────────────────────────────────────
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="판례 issue 컬럼 임베딩 (Vertex AI + KURE-v1)"
-    )
-    parser.add_argument(
-        "--model",
-        choices=["vertex", "kure", "e5", "kolegal", "all"],
-        default="all",
-        help="실행할 임베딩 모델 선택 (default: all)",
+        description="판례 judgement_summary 컬럼 임베딩 (Vertex AI)"
     )
     parser.add_argument(
         "--input",  default=str(INPUT_CSV),
@@ -69,20 +43,12 @@ def parse_args() -> argparse.Namespace:
     )
     return parser.parse_args()
 
-# ── 텍스트 선택 함수 ─────────────────────────────────────────────
-def select_js_text(row: pd.Series, max_chars: int) -> str:
-    """judgment_summary 우선, 없으면 issue로 fallback하고 truncate한다."""
-    summary = str(row.get("judgment_summary") or "").strip()
-    issue   = str(row.get("issue") or "").strip()
-    text    = summary if summary else issue
-    return text[:max_chars]
-
 
 # ── 데이터 로드 / 체크포인트 복원 ─────────────────────────────────────────────
 def load_data(input_path: str, output_path: str) -> pd.DataFrame:
     """
     출력 파일이 이미 있으면 해당 파일을 기준으로 미완료 행만 처리.
-    없으면 입력 파일을 읽고 embed_vertex / embed_kure 컬럼을 추가.
+    없으면 입력 파일을 읽고 embed_vertex 컬럼을 추가.
     """
     output_p = Path(output_path)
     if output_p.exists():
@@ -96,22 +62,28 @@ def load_data(input_path: str, output_path: str) -> pd.DataFrame:
 
     if "embed_vertex" not in df.columns:
         df["embed_vertex"] = None
-    if "embed_kure" not in df.columns:
-        df["embed_kure"] = None
-        
-    for col in (
-    COL_E5,
-    COL_VERTEX_JS,
-    COL_KURE_JS,
-    COL_E5_JS,
-    COL_KOLEGAL,
-    COL_KOLEGAL_JS,
-    ):
-        if col not in df.columns:
-            df[col] = None
 
     return df
 
+# ── 텍스트 선택 함수 ─────────────────────────────────────────────
+
+def select_embedding_text(
+    row: pd.Series,
+) -> str:
+    """
+    judgment_summary 우선 사용,
+    없으면 issue fallback.
+    """
+
+    summary = str(
+        row.get("judgment_summary") or ""
+    ).strip()
+
+    issue = str(
+        row.get("issue") or ""
+    ).strip()
+
+    return summary if summary else issue
 
 # ── Vertex AI 임베딩 ───────────────────────────────────────────────────────────
 def run_vertex_embedding(df: pd.DataFrame, output_path: str) -> pd.DataFrame:
@@ -127,14 +99,12 @@ def run_vertex_embedding(df: pd.DataFrame, output_path: str) -> pd.DataFrame:
 
     client = genai.Client(vertexai=True, project=project_id, location=location)
 
-    targets = []
-    for idx, r in df.iterrows():
-        issue_text = str(r.get("issue") or "").strip()
-        js_text    = select_js_text(r, MAX_CHARS_VERTEX)
-        need_issue = bool(issue_text) and pd.isna(r[COL_VERTEX])
-        need_js    = bool(js_text)    and pd.isna(r[COL_VERTEX_JS])
-        if need_issue or need_js:
-            targets.append((idx, issue_text, js_text, need_issue, need_js))
+    targets = [
+        (idx, select_embedding_text(r))
+        for idx, r in df.iterrows()
+        if select_embedding_text(r)
+        and pd.isna(r["embed_vertex"]) 
+    ]
 
     print(f"\n[Vertex AI] 임베딩 대상: {len(targets)}건 (모델: {VERTEX_MODEL})")
     if not targets:
@@ -143,35 +113,19 @@ def run_vertex_embedding(df: pd.DataFrame, output_path: str) -> pd.DataFrame:
 
     errors, start = [], time.time()
 
-    for i, (idx, issue_text, js_text, need_issue, need_js) in enumerate(targets):
+    for i, (idx, text) in enumerate(targets):
         for attempt in range(1, MAX_RETRIES + 1):
             try:
-                # issue 기반 임베딩
-                if need_issue and pd.isna(df.at[idx, COL_VERTEX]):
-                    resp = client.models.embed_content(
-                        model=VERTEX_MODEL,
-                        contents=issue_text,
-                        config=types.EmbedContentConfig(
-                            task_type="RETRIEVAL_DOCUMENT",
-                            output_dimensionality=VERTEX_DIM,
-                        ),
-                    )
-                    df.at[idx, COL_VERTEX] = json.dumps(resp.embeddings[0].values)
-                    time.sleep(SLEEP_SEC)
- 
-                # judgment_summary 기반 임베딩
-                if need_js and pd.isna(df.at[idx, COL_VERTEX_JS]):
-                    resp = client.models.embed_content(
-                        model=VERTEX_MODEL,
-                        contents=js_text,
-                        config=types.EmbedContentConfig(
-                            task_type="RETRIEVAL_DOCUMENT",
-                            output_dimensionality=VERTEX_DIM,
-                        ),
-                    )
-                    df.at[idx, COL_VERTEX_JS] = json.dumps(resp.embeddings[0].values)
-                    time.sleep(SLEEP_SEC)
- 
+                resp = client.models.embed_content(
+                    model=VERTEX_MODEL,
+                    contents=text,
+                    config=types.EmbedContentConfig(
+                        task_type="RETRIEVAL_DOCUMENT",
+                        output_dimensionality=VERTEX_DIM,
+                    ),
+                )
+                df.at[idx, "embed_vertex"] = json.dumps(resp.embeddings[0].values)
+                time.sleep(SLEEP_SEC)
                 break
             except Exception as e:
                 if attempt == MAX_RETRIES:
@@ -186,217 +140,41 @@ def run_vertex_embedding(df: pd.DataFrame, output_path: str) -> pd.DataFrame:
             elapsed = time.time() - start
             print(f"  [{i+1}/{len(targets)}] {elapsed:.1f}s | 평균 {elapsed/(i+1):.2f}s/건")
             df.to_csv(output_path, index=False, encoding="utf-8-sig")  # 중간 저장
+    
+    keep_cols = [
+    "case_id",
+    "case_name",
+    "issue",
+    "judgment_summary",
+    "embed_vertex",
+    ]
+
+    existing_cols = [ c for c in keep_cols if c in df.columns]
+
+    df = df[existing_cols]
 
     df.to_csv(output_path, index=False, encoding="utf-8-sig")
     total = time.time() - start
-    print(
-        f"[Vertex AI] 완료 — "
-        f"issue: {df[COL_VERTEX].notna().sum()}건 | "
-        f"js: {df[COL_VERTEX_JS].notna().sum()}건 | "
-        f"실패: {len(errors)}건 | "
-        f"소요: {total:.1f}s ({total/60:.1f}분)"
-    )
-    return df
-
-# ── KURE-v1 임베딩 ─────────────────────────────────────────────────────────────
-def run_kure_embedding(df: pd.DataFrame, output_path: str) -> pd.DataFrame:
-    from sentence_transformers import SentenceTransformer
-
-    targets_issue = [
-        idx for idx, r in df.iterrows()
-        if str(r.get("issue") or "").strip() and pd.isna(r[COL_KURE])
-    ]
-    targets_js = [
-        idx for idx, r in df.iterrows()
-        if select_js_text(r, MAX_CHARS_KURE) and pd.isna(r[COL_KURE_JS])
-    ]
-
-    print(f"\n[KURE-v1] issue 대상: {len(targets_issue)}건 | js 대상: {len(targets_js)}건")
-    if not targets_issue and not targets_js:
-        print("[KURE-v1] 모두 완료됨, 스킵")
-        return df
-
-    print("모델 로딩 중...")
-    model = SentenceTransformer(KURE_MODEL)
-
-    if targets_issue:
-        texts_issue = [str(df.at[idx, "issue"]) for idx in targets_issue]
-        emb_issue = model.encode(texts_issue, batch_size=BATCH_SIZE,
-                                 show_progress_bar=True, normalize_embeddings=True)
-        for i, idx in enumerate(targets_issue):
-            df.at[idx, COL_KURE] = json.dumps(emb_issue[i].tolist())
-        df.to_csv(output_path, index=False, encoding="utf-8-sig")
-        print(f"[KURE-v1 issue] 완료 — {len(targets_issue)}건, 차원: {emb_issue.shape[1]}")
-
-    if targets_js:
-        texts_js = [select_js_text(df.loc[idx], MAX_CHARS_KURE) for idx in targets_js]
-        emb_js = model.encode(texts_js, batch_size=BATCH_SIZE,
-                              show_progress_bar=True, normalize_embeddings=True)
-        for i, idx in enumerate(targets_js):
-            df.at[idx, COL_KURE_JS] = json.dumps(emb_js[i].tolist())
-        df.to_csv(output_path, index=False, encoding="utf-8-sig")
-        print(f"[KURE-v1 js] 완료 — {len(targets_js)}건, 차원: {emb_js.shape[1]}")
-
-    return df
-
-# ── E5 임베딩 ──────────────────────────────────────────────────────────
-def run_e5_embedding(df: pd.DataFrame, output_path: str) -> pd.DataFrame:
-    """E5: issue 기반(embed_e5) + judgment_summary 기반(embed_e5_js) 모두 생성."""
-    from sentence_transformers import SentenceTransformer
-
-    targets_issue = [
-        idx for idx, r in df.iterrows()
-        if str(r.get("issue") or "").strip() and pd.isna(r[COL_E5])
-    ]
-    targets_js = [
-        idx for idx, r in df.iterrows()
-        if select_js_text(r, MAX_CHARS_E5) and pd.isna(r[COL_E5_JS])
-    ]
-
-    print(f"\n[E5] issue 대상: {len(targets_issue)}건 | js 대상: {len(targets_js)}건")
-    if not targets_issue and not targets_js:
-        print("[E5] 모두 완료됨, 스킵")
-        return df
-
-    print("모델 로딩 중...")
-    model = SentenceTransformer(E5_MODEL)
-
-    # issue 기반 임베딩
-    if targets_issue:
-        texts_issue = ["passage: " + str(df.at[idx, "issue"]) for idx in targets_issue]
-        emb_issue = model.encode(texts_issue, batch_size=BATCH_SIZE,
-                                 show_progress_bar=True, normalize_embeddings=True)
-        for i, idx in enumerate(targets_issue):
-            df.at[idx, COL_E5] = json.dumps(emb_issue[i].tolist())
-        df.to_csv(output_path, index=False, encoding="utf-8-sig")
-        print(f"[E5 issue] 완료 — {len(targets_issue)}건, 차원: {emb_issue.shape[1]}")
-
-    # judgment_summary 기반 임베딩
-    if targets_js:
-        texts_js = ["passage: " + select_js_text(df.loc[idx], MAX_CHARS_E5) for idx in targets_js]
-        emb_js = model.encode(texts_js, batch_size=BATCH_SIZE,
-                              show_progress_bar=True, normalize_embeddings=True)
-        for i, idx in enumerate(targets_js):
-            df.at[idx, COL_E5_JS] = json.dumps(emb_js[i].tolist())
-        df.to_csv(output_path, index=False, encoding="utf-8-sig")
-        print(f"[E5 js] 완료 — {len(targets_js)}건, 차원: {emb_js.shape[1]}")
-
+    print(f"[Vertex AI] 완료 — 성공: {df['embed_vertex'].notna().sum()}건 | "
+          f"실패: {len(errors)}건 | 소요: {total:.1f}s ({total/60:.1f}분)")
     return df
 
 
-# ── KoLegal 임베딩 ──────────────────────────────────────────────────────────
-def run_kolegal_embedding(df: pd.DataFrame, output_path: str) -> pd.DataFrame:
-    from sentence_transformers import SentenceTransformer
-
-    targets_issue = [
-        idx for idx, r in df.iterrows()
-        if str(r.get("issue") or "").strip() and pd.isna(r[COL_KOLEGAL])
-    ]
-
-    targets_js = [
-        idx for idx, r in df.iterrows()
-        if select_js_text(r, MAX_CHARS_KURE) and pd.isna(r[COL_KOLEGAL_JS])
-    ]
-
-    print(
-        f"\n[KoLegal] issue 대상: {len(targets_issue)}건 | "
-        f"js 대상: {len(targets_js)}건"
-    )
-
-    if not targets_issue and not targets_js:
-        print("[KoLegal] 모두 완료됨, 스킵")
-        return df
-
-    print("모델 로딩 중...")
-    model = SentenceTransformer(KOLEGAL_MODEL)
-
-    # issue 기반 임베딩
-    if targets_issue:
-        texts_issue = [
-            str(df.at[idx, "issue"])
-            for idx in targets_issue
-        ]
-
-        emb_issue = model.encode(
-            texts_issue,
-            batch_size=BATCH_SIZE,
-            show_progress_bar=True,
-            normalize_embeddings=True,
-        )
-
-        for i, idx in enumerate(targets_issue):
-            df.at[idx, COL_KOLEGAL] = json.dumps(
-                emb_issue[i].tolist()
-            )
-
-        df.to_csv(output_path, index=False, encoding="utf-8-sig")
-
-        print(
-            f"[KoLegal issue] 완료 — "
-            f"{len(targets_issue)}건, 차원: {emb_issue.shape[1]}"
-        )
-
-    # judgment_summary 기반 임베딩
-    if targets_js:
-        texts_js = [
-            select_js_text(df.loc[idx], MAX_CHARS_KURE)
-            for idx in targets_js
-        ]
-
-        emb_js = model.encode(
-            texts_js,
-            batch_size=BATCH_SIZE,
-            show_progress_bar=True,
-            normalize_embeddings=True,
-        )
-
-        for i, idx in enumerate(targets_js):
-            df.at[idx, COL_KOLEGAL_JS] = json.dumps(
-                emb_js[i].tolist()
-            )
-
-        df.to_csv(output_path, index=False, encoding="utf-8-sig")
-
-        print(
-            f"[KoLegal js] 완료 — "
-            f"{len(targets_js)}건, 차원: {emb_js.shape[1]}"
-        )
-
-    return df
-
-# ── 진입점 ────────────────────────────────────────────────────────────────────
+# ── 진입점 ─────────────────────────────────────────────────────────────────────
 def main() -> None:
     args = parse_args()
     df = load_data(args.input, args.output)
- 
-    print(f"전체: {len(df)}건")
-    print(f"  issue 있음:              {df['issue'].notna().sum()}건")
-    print(f"  judgment_summary 있음:   {df['judgment_summary'].notna().sum()}건")
-    print(f"  js 텍스트 선택 가능:     {sum(bool(select_js_text(r, MAX_CHARS_VERTEX)) for _, r in df.iterrows())}건")
- 
-    if args.model in ("vertex", "all"):
-        df = run_vertex_embedding(df, args.output)
- 
-    if args.model in ("kure", "all"):
-        df = run_kure_embedding(df, args.output)
- 
-    if args.model in ("e5", "all"):
-        df = run_e5_embedding(df, args.output)
-    
-    if args.model in ("kolegal", "all"):
-        df = run_kolegal_embedding(df, args.output)
-        
+
+    total_rows = len(df)
+    target_rows = df["judgment_summary"].notna().sum()
+    print(f"전체: {total_rows}건 | judgment_summary 비어있지 않은 행: {target_rows}건")
+
+    df = run_vertex_embedding(df, args.output)
+
     print(f"\n=== 완료 ===")
-    print(f"embed_vertex    완료: {df[COL_VERTEX].notna().sum()}건")
-    print(f"embed_kure      완료: {df[COL_KURE].notna().sum()}건")
-    print(f"embed_e5        완료: {df[COL_E5].notna().sum()}건")
-    print(f"embed_kolegal    완료: {df[COL_KOLEGAL].notna().sum()}건")
-    print(f"embed_vertex_js 완료: {df[COL_VERTEX_JS].notna().sum()}건")
-    print(f"embed_kure_js   완료: {df[COL_KURE_JS].notna().sum()}건")
-    print(f"embed_e5_js     완료: {df[COL_E5_JS].notna().sum()}건")
-    print(f"embed_kolegal_js 완료: {df[COL_KOLEGAL_JS].notna().sum()}건")
+    print(f"embed_vertex 완료: {df['embed_vertex'].notna().sum()}건")
     print(f"저장 경로: {args.output}")
- 
- 
+
+
 if __name__ == "__main__":
     main()

--- a/data/processors/law_embedder.py
+++ b/data/processors/law_embedder.py
@@ -2,7 +2,8 @@
 
 사용 모델:
 - Vertex AI: gemini-embedding-001 (3072차원)
-- KURE-v1: nlpai-lab/KURE-v1 (1024차원)
+
+임베딩 텍스트: parent_text + child_text (prefix 방식)
 """
 
 import json
@@ -18,25 +19,17 @@ load_dotenv(Path(__file__).parent.parent.parent / ".env")
 # ── 경로 설정 ─────────────────────────────────────────────────────────
 
 DATA_DIR = Path(__file__).parent.parent
-INPUT_PATH = DATA_DIR / "raw" / "law_child.csv"
-OUTPUT_PATH = DATA_DIR / "raw" / "law_child.csv"
+INPUT_CHILD_PATH = DATA_DIR / "raw" / "law_child.csv"
+INPUT_PARENT_PATH = DATA_DIR / "raw" / "law_parent.csv"
+OUTPUT_PATH = DATA_DIR / "raw" / "law_child_vertex.csv"
 
 # ── 상수 ──────────────────────────────────────────────────────────────
 
 VERTEX_MODEL = "gemini-embedding-001"
-KURE_MODEL = "nlpai-lab/KURE-v1"
-KOLEGAL_MODEL = "woong0322/ko-legal-sbert-finetuned"
-E5_MODEL = "intfloat/multilingual-e5-large"
 
 # Vertex AI 배치 크기 (API 제한: 최대 250)
 VERTEX_BATCH_SIZE = 100
-# KURE 배치 크기 (메모리 상황에 따라 조정)
-KURE_BATCH_SIZE = 64
 
-E5_DOC_PREFIX = "passage: "
-E5_BATCH_SIZE = 32
-
-KOLEGAL_BATCH_SIZE = 64
 
 # ── Vertex AI 임베딩 ──────────────────────────────────────────────────
 
@@ -83,162 +76,78 @@ def embed_vertex(texts: list[str]) -> list[list[float]]:
     return results
 
 
-# ── KURE 임베딩 ───────────────────────────────────────────────────────
-
-def init_kure():
-    """KURE 모델을 로딩한다."""
-    from sentence_transformers import SentenceTransformer
-
-    print(f"  KURE 모델 로딩 중: {KURE_MODEL}")
-    model = SentenceTransformer(KURE_MODEL)
-    print("  KURE 모델 로딩 완료")
-    return model
-
-
-def embed_kure(texts: list[str], model) -> list[list[float]]:
-    """전체 텍스트 목록을 KURE로 배치 임베딩한다."""
-    results = []
-    total = len(texts)
-
-    for i in range(0, total, KURE_BATCH_SIZE):
-        batch = texts[i: i + KURE_BATCH_SIZE]
-        print(f"    KURE 배치 {i // KURE_BATCH_SIZE + 1} / {(total - 1) // KURE_BATCH_SIZE + 1} ({len(batch)}건)")
-        vectors = model.encode(batch, show_progress_bar=False)
-        results.extend(vectors.tolist())
-
-    return results
-
-# ── E2 임베딩 ────────────────────────────────────────────────────────────
-
-def init_e5():
-    from sentence_transformers import SentenceTransformer
-    print(f"  E5 모델 로딩 중: {E5_MODEL}")
-    model = SentenceTransformer(E5_MODEL)
-    print("  E5 모델 로딩 완료")
-    return model
-
-
-def embed_e5(texts: list[str], model) -> list[list[float]]:
-    # 문서 측 입력에 "passage: " 접두어 필요
-    prefixed = [E5_DOC_PREFIX + t for t in texts]
-    results = []
-    total = len(prefixed)
-    for i in range(0, total, E5_BATCH_SIZE):
-        batch = prefixed[i: i + E5_BATCH_SIZE]
-        print(f"    E5 배치 {i // E5_BATCH_SIZE + 1} / {(total - 1) // E5_BATCH_SIZE + 1} ({len(batch)}건)")
-        results.extend(model.encode(batch, normalize_embeddings=True, show_progress_bar=False).tolist())
-    return results
-
-# ── kolegal 임베딩 ────────────────────────────────────────────────────────────
-
-def init_kolegal():
-    """KoLegal 모델을 로딩한다."""
-    from sentence_transformers import SentenceTransformer
-
-    print(f"  KoLegal 모델 로딩 중: {KOLEGAL_MODEL}")
-    model = SentenceTransformer(KOLEGAL_MODEL)
-    print("  KoLegal 모델 로딩 완료")
-
-    return model
-
-def embed_kolegal(texts: list[str], model) -> list[list[float]]:
-    """전체 텍스트 목록을 KoLegal로 배치 임베딩한다."""
-    results = []
-    total = len(texts)
-
-    for i in range(0, total, KOLEGAL_BATCH_SIZE):
-        batch = texts[i: i + KOLEGAL_BATCH_SIZE]
-
-        print(
-            f"    KoLegal 배치 "
-            f"{i // KOLEGAL_BATCH_SIZE + 1} / "
-            f"{(total - 1) // KOLEGAL_BATCH_SIZE + 1} "
-            f"({len(batch)}건)"
-        )
-
-        vectors = model.encode(
-            batch,
-            show_progress_bar=False,
-            normalize_embeddings=True,
-        )
-
-        results.extend(vectors.tolist())
-
-    return results
-
 # ── 실행부 ────────────────────────────────────────────────────────────
 
 def run(
-    input_path: str | Path = INPUT_PATH,
+    input_child_path: str | Path = INPUT_CHILD_PATH,
+    input_parent_path: str | Path = INPUT_PARENT_PATH,
     output_path: str | Path = OUTPUT_PATH,
-    use_vertex: bool = True,
-    use_kure: bool = True,
-    use_e5: bool = True,
-    use_kolegal: bool = True,
 ) -> None:
-    """child CSV에 임베딩 컬럼을 추가한다.
-    
-    각 모델별로 컬럼이 이미 존재하면 해당 모델 임베딩을 건너뛴다.
+    """child CSV에 parent_text 컬럼 및 임베딩 컬럼을 추가한다.
+
+    - law_child와 law_parent를 article_key로 JOIN
+    - 임베딩 텍스트: parent_text + child_text (prefix 방식)
+    - embed_vertex 컬럼이 이미 존재하면 임베딩을 건너뜀
     """
-    input_path = Path(input_path)
+    input_child_path = Path(input_child_path)
+    input_parent_path = Path(input_parent_path)
     output_path = Path(output_path)
 
-    print(f"[법령 embedder] 입력: {input_path}")
+    print(f"[법령 embedder] child 입력: {input_child_path}")
+    print(f"[법령 embedder] parent 입력: {input_parent_path}")
     print(f"[법령 embedder] 출력: {output_path}")
 
-    df = pd.read_csv(input_path, dtype={"paragraph_no": str})
-    texts = df["child_text"].fillna("").tolist()
-    print(f"  총 {len(texts)}건 로드 완료")
+    # child, parent 로드
+    df_child = pd.read_csv(input_child_path, dtype={"paragraph_no": str})
+    df_parent = pd.read_csv(input_parent_path)[["article_key", "parent_text"]]
+    print(f"  child {len(df_child)}건, parent {len(df_parent)}건 로드 완료")
 
-    step = 1
+    # article_key로 JOIN하여 parent_text 추가
+    df = df_child.merge(df_parent, on="article_key", how="left")
 
-    if use_vertex:
-        if "embed_vertex" in df.columns:
-            print(f"\n[{step}] embed_vertex 컬럼 존재 → 건너뜀")
-        else:
-            print(f"\n[{step}] Vertex AI 임베딩 시작 (모델: {VERTEX_MODEL})")
-            init_vertex()
-            vectors = embed_vertex(texts)
-            df["embed_vertex"] = [json.dumps(v) for v in vectors]
-            print(f"  완료: {len(vectors)}건, 차원: {len(vectors[0])}")
-        step += 1
+    # JOIN 결과 확인
+    missing = df["parent_text"].isna().sum()
+    if missing > 0:
+        print(f"  경고: parent_text 매핑 실패 {missing}건 (article_key 불일치)")
 
-    if use_kure:
-        if "embed_kure" in df.columns:
-            print(f"\n[{step}] embed_kure 컬럼 존재 → 건너뜀")
-        else:
-            print(f"\n[{step}] KURE 임베딩 시작 (모델: {KURE_MODEL})")
-            kure_model = init_kure()
-            vectors = embed_kure(texts, kure_model)
-            df["embed_kure"] = [json.dumps(v) for v in vectors]
-            print(f"  완료: {len(vectors)}건, 차원: {len(vectors[0])}")
-        step += 1
+    print(f"\n[1] Vertex AI 임베딩 시작 (모델: {VERTEX_MODEL})")
 
-    if use_e5:
-        if "embed_e5" in df.columns:
-            print(f"\n[{step}] embed_e5 컬럼 존재 → 건너뜀")
-        else:
-            print(f"\n[{step}] E5 임베딩 시작 (모델: {E5_MODEL})")
-            e5_model = init_e5()
-            vectors = embed_e5(texts, e5_model)
-            df["embed_e5"] = [json.dumps(v) for v in vectors]
-            print(f"  완료: {len(vectors)}건, 차원: {len(vectors[0])}")
-        step += 1
+    if "embed_vertex" in df.columns:
+        print("  embed_vertex 컬럼 존재 → 건너뜀")
+    else:
+        init_vertex()
 
-    if use_kolegal:
-        if "embed_kolegal" in df.columns:
-            print(f"\n[{step}] embed_kolegal 컬럼 존재 → 건너뜀")
-        else:
-            print(f"\n[{step}] KoLegal 임베딩 시작 (모델: {KOLEGAL_MODEL})")
-            kolegal_model = init_kolegal()
-            vectors = embed_kolegal(texts, kolegal_model)
-            df["embed_kolegal"] = [json.dumps(v) for v in vectors]
-            print(f"  완료: {len(vectors)}건, 차원: {len(vectors[0])}")
-        step += 1
-        
+        # 임베딩 텍스트: parent_text를 prefix로 붙인 뒤 child_text 결합
+        def build_embed_text(row) -> str:
+            parent = row["parent_text"] if pd.notna(row["parent_text"]) else ""
+            child = row["child_text"] if pd.notna(row["child_text"]) else ""
+            if parent:
+                return f"{parent}\n\n{child}"
+            return child
+
+        embed_texts = df.apply(build_embed_text, axis=1).tolist()
+
+        vectors = embed_vertex(embed_texts)
+        df["embed_vertex"] = [json.dumps(v) for v in vectors]
+        print(f"  완료: {len(vectors)}건, 차원: {len(vectors[0])}")
+
+    # 저장할 컬럼 순서 정의
+    keep_cols = [
+        "clause_key",
+        "article_key",
+        "law_name",
+        "article_no",
+        "paragraph_no",
+        "child_text",
+        "parent_text",
+        "embed_vertex",
+    ]
+
+    existing_cols = [c for c in keep_cols if c in df.columns]
+    df = df[existing_cols]
+
     df.to_csv(output_path, index=False, encoding="utf-8-sig", quoting=csv.QUOTE_ALL)
     print(f"\n저장 완료: {output_path}")
-    
     
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
## 📝 변경 사항
- Dense Retrieval 임베딩 모델을 Vertex 기반으로 단일화
- 법령 임베딩 코드에서 KURE / E5 / KoLegal 관련 로직 제거
- 판례 임베딩 코드에서 KURE / E5 / KoLegal 및 _js 기반 임베딩 구조 제거
- 판례 임베딩 시 judgment_summary 우선 사용, 값이 없는 경우 issue fallback 적용
- 최종 임베딩 컬럼을 embed_vertex로 통일

## 🔗 관련 이슈
closes #91

## 📸 스크린샷 (선택)
없음

## 🧪 테스트
- 로컬 테스트 결과 CSV 파일 정상 생성 확인
- embed_vertex 컬럼 정상 생성 확인
- judgment_summary null 케이스 fallback 동작 확인
- 기존 임베딩 컬럼 제거 후 저장 확인

## ✅ 체크리스트
- [X] 코드가 정상적으로 동작합니다.
- [X] 커밋 메시지가 컨벤션을 따릅니다.
- [X] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
- Dense Retrieval 실험 결과 Vertex embedding이 가장 높은 성능을 보여 운영 모델을 Vertex로 단일화했습니다.
- 판례 임베딩은 judgment_summary 기반으로 변경했으며, 값이 없는 경우 issue를 fallback으로 사용하도록 처리했습니다.
- 기존 임베딩 컬럼들은 제거 후 embed_vertex만 유지하도록 정리했습니다.