### PR TITLE
[PR] 분석 결과 UI 고도화 및 조항별 내비게이션 기능 개선 (#106)

### DIFF
--- a/frontend/components/analysis/DocumentPanel.tsx
+++ b/frontend/components/analysis/DocumentPanel.tsx
@@ -1,46 +1,23 @@
 "use client";
 
-type Article = {
+type GeneralTerm = {
   title: string;
-  items: string[];
+  text: string;
 };
 
 type DocumentPanelProps = {
   contractTitle?: string;
-  articles: Article[];
+  specialTerms: string[];
+  generalTerms: GeneralTerm[];
+  onTermClick?: (index: number) => void;
 };
 
-function ArticleBlock({ article }: { article: Article }) {
-  return (
-    <div className="flex flex-col gap-[5px] pt-4">
-      <p
-        className="text-sm font-bold"
-        style={{ color: "#1A1C1E", fontFamily: "var(--font-public-sans)", lineHeight: "23px" }}
-      >
-        {article.title}
-      </p>
-      {article.items.map((text, i) => (
-        <div
-          key={i}
-          className="px-0 py-[10px]"
-          style={{
-            paddingLeft: "24px",
-            border: "1px solid #E5EAF1",
-          }}
-        >
-          <p
-            className="text-sm"
-            style={{ color: "#1A1C1E", fontFamily: "var(--font-public-sans)", lineHeight: "23px" }}
-          >
-            {text}
-          </p>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-export function DocumentPanel({ contractTitle, articles }: DocumentPanelProps) {
+export function DocumentPanel({ 
+  contractTitle, 
+  specialTerms, 
+  generalTerms,
+  onTermClick 
+}: DocumentPanelProps) {
   return (
     <section
       className="flex flex-col overflow-y-auto"
@@ -76,11 +53,53 @@ export function DocumentPanel({ contractTitle, articles }: DocumentPanelProps) {
         </p>
       </div>
 
-      {/* Articles */}
-      <div className="flex flex-col gap-[15px]">
-        {articles.map((article, i) => (
-          <ArticleBlock key={i} article={article} />
-        ))}
+      <div className="flex flex-col gap-8 py-6">
+        {/* 1. 특약 사항 섹션 (최상단) */}
+        {specialTerms.length > 0 && (
+          <div className="flex flex-col gap-4">
+            <h3 className="px-2 text-sm font-black text-blue-700 uppercase tracking-widest border-l-4 border-blue-600">
+              특약 사항
+            </h3>
+            <div className="flex flex-col gap-2">
+              {specialTerms.map((text, i) => (
+                <button
+                  key={i}
+                  onClick={() => onTermClick?.(i)}
+                  className="group flex flex-col gap-1 rounded-lg border border-gray-200 bg-gray-50 p-4 text-left transition hover:border-blue-300 hover:bg-blue-50 hover:shadow-sm"
+                >
+                  <span className="text-[10px] font-bold text-gray-400 uppercase group-hover:text-blue-500">특약 {i + 1}</span>
+                  <p className="text-sm text-gray-800 leading-relaxed font-medium">
+                    {text}
+                  </p>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 구분선 */}
+        <div className="h-px bg-gray-100 mx-2" />
+
+        {/* 2. 일반 조항 섹션 */}
+        {generalTerms.length > 0 && (
+          <div className="flex flex-col gap-4">
+            <h3 className="px-2 text-sm font-black text-gray-500 uppercase tracking-widest border-l-4 border-gray-300">
+              일반 조항
+            </h3>
+            <div className="flex flex-col gap-4">
+              {generalTerms.map((term, i) => (
+                <div key={i} className="flex flex-col gap-1 px-2">
+                  <p className="text-xs font-bold text-gray-500">{term.title}</p>
+                  <div className="p-3 border rounded bg-white border-gray-100">
+                    <p className="text-xs text-gray-600 leading-relaxed">
+                      {term.text}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/frontend/components/analysis/LawSection.tsx
+++ b/frontend/components/analysis/LawSection.tsx
@@ -28,17 +28,16 @@ function LawCard({ item }: { item: LawItem }) {
       <div className="flex flex-row items-center gap-[10px]">
         <NumberBadge n={item.rank} />
         <p
-          className="text-sm font-medium"
-          style={{ color: "#1A1C1E", fontFamily: "var(--font-public-sans)", lineHeight: "22px" }}
+          className="text-sm font-semibold"
+          style={{ color: "#002045", fontFamily: "var(--font-public-sans)", lineHeight: "22px" }}
         >
           {item.name}
         </p>
       </div>
 
-      {/* Warning + detail */}
+      {/* Warning banner */}
       {item.warning && (
         <div className="flex flex-col gap-[5px] pl-9">
-          {/* Warning banner */}
           <div
             className="flex flex-row items-center gap-3 p-3 rounded-sm"
             style={{ background: "#FEE2E2", border: "1px solid #F65746" }}
@@ -55,21 +54,27 @@ function LawCard({ item }: { item: LawItem }) {
               {item.warning}
             </p>
           </div>
+        </div>
+      )}
 
-          {/* Detail with left border */}
-          {item.detail && (
-            <div
-              className="flex items-center px-[10px] py-0"
-              style={{ borderLeft: "2px solid #F65746", minHeight: "40px" }}
+      {/* Detail (Law Content) - Always Visible */}
+      {item.detail && (
+        <div className="pl-9">
+          <div
+            className="px-4 py-3 rounded-md"
+            style={{ 
+              background: "#F8FAFC", 
+              borderLeft: `4px solid ${item.warning ? "#F65746" : "#455F88"}`,
+              boxShadow: "inset 0 1px 2px rgba(0,0,0,0.02)"
+            }}
+          >
+            <p
+              className="text-sm whitespace-pre-wrap"
+              style={{ color: "#334155", fontFamily: "var(--font-public-sans)", lineHeight: "1.6" }}
             >
-              <p
-                className="text-sm"
-                style={{ color: "#1A1C1E", fontFamily: "var(--font-public-sans)", lineHeight: "20px" }}
-              >
-                {item.detail}
-              </p>
-            </div>
-          )}
+              {item.detail}
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -6,12 +6,7 @@
       "**/.*",
       "**/node_modules/**"
     ],
-    "trailingSlash": false,
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
+    "cleanUrls": true,
+    "trailingSlash": false
   }
 }


### PR DESCRIPTION
📝 변경 사항
- 특약 사항 가시성 강화: 사용자의 핵심 분석 대상인 '특약 사항'을 문서 패널(왼쪽)의 최상단 섹션으로 이동시키고, 개별 카드로 시각화하여 일반 조항과 명확히 분리했습니다.
- 조항별 결과 그룹화: 분석 결과를 단순히 나열하던 방식에서 벗어나, 각 특약별로 검색된 법령과 판례를 묶어서 보여주는 구조로 전면 리팩토링했습니다.
- 실시간 내비게이션(Scroll-to-view) 도입: 왼쪽 문서 패널에서 특정 특약을 클릭하면, 오른쪽 분석 결과 화면에서 해당 항목의 위치로 부드럽게 스크롤되는 기능을 구현하여 사용자 탐색 편의성을 극대화했습니다.
- 법령 조문 상세 노출: 관련 법령 섹션에서 조항 이름뿐만 아니라 실제 조문 본문(detail)을 항상 확인할 수 있도록 개선하고, 가독성을 위해 whitespace-pre-wrap 스타일을 적용했습니다.
- 비동기 실시간 렌더링 통합: 개별 특약 분석이 완료되는 즉시 화면에 결과가 반영되도록 프론트엔드 상태 관리 로직을 고도화했습니다.

🔗 관련 이슈
closes #106

🧪 테스트
- [x] 특약 클릭 시 scrollIntoView가 정확한 ID(analysis-result-{idx})를 찾아 이동하는지 확인
- [x] 분석 결과가 도착할 때마다 리스트가 동적으로 업데이트되면서도 기존 스크롤 위치를 방해하지 않는지 검증
- [x] 모바일 및 다양한 브라우저 크기에서 왼쪽/오른쪽 패널의 독립적인 스크롤 동작 확인

✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 추가/수정했습니다.
- [x] 문서를 업데이트했습니다 (UI 컴포넌트 명세).

💬 리뷰어에게
DocumentPanel.tsx에서 특약 사항을 클릭했을 때 발생하는 onTermClick 이벤트와 AnalysisPage의 handleTermClick 함수 간의 연동
부분을 중점적으로 봐주시면 감사하겠습니다. 또한, 법령 본문 노출 시 박스 디자인이 전체적인 톤앤매너와 잘 어울리는지도 검토
부탁드립니다.