### PR TITLE
[PR] 병렬 분석 아키텍처 도입 및 히스토리 관리 기능 구현 (#105)

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,5 +1,7 @@
+"""API 요청/응답 스키마."""
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel
@@ -8,18 +10,128 @@ from pipeline.preprocessing.schema import LeaseContract
 from pipeline.retrieval.query_expansion.query_expansion_schema import ClauseQueryExpansion
 
 
+# ──────────────────────────────────────────────────────────────────────
+# 공통
+# ──────────────────────────────────────────────────────────────────────
+
 class HealthResponse(BaseModel):
     status: str
 
 
-class SpecialTermExpansionResult(BaseModel):
+# ──────────────────────────────────────────────────────────────────────
+# 새로운 병렬 아키텍처용 스키마
+# ──────────────────────────────────────────────────────────────────────
+
+class DocumentHistoryItem(BaseModel):
+    doc_id: str
+    file_name: str
+    created_at: datetime
+    gcs_raw_path: str
+    gcs_parsed_path: str
+
+
+class DocumentHistoryResponse(BaseModel):
+    documents: list[DocumentHistoryItem]
+
+
+class DocumentUploadResponse(BaseModel):
+    doc_id: str
+    contract: LeaseContract
+
+
+class AnalyzeClauseRequest(BaseModel):
+    client_id: str
+    doc_id: str
+    clause_index: int
+    clause_text: str
+
+
+class ClauseAnalysisResponse(BaseModel):
     index: int
-    special_term: str
+    clause: str
+    expansion: ClauseQueryExpansion
+    top_results: list[RankedDocument]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 기존 (레거시)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class LayoutParseResponse(BaseModel):
+    contract: LeaseContract
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 2단계: query_expansion  (layout_parse 결과 포함)
+# ──────────────────────────────────────────────────────────────────────
+
+class ClauseExpansion(BaseModel):
+    index: int
+    clause: str
     expansion: ClauseQueryExpansion
     retrieval_payload: dict[str, Any]
 
 
-class ContractAnalysisResponse(BaseModel):
+class QueryExpansionResponse(BaseModel):
     contract: LeaseContract
-    special_term_expansions: list[SpecialTermExpansionResult]
+    clauses: list[ClauseExpansion]
 
+
+# ──────────────────────────────────────────────────────────────────────
+# 3단계: retrieval  (query_expansion 결과 포함)
+# ──────────────────────────────────────────────────────────────────────
+
+class RetrievalHit(BaseModel):
+    doc_id: str
+    source_type: str          # "law" | "precedent"
+    rank: int
+    rrf_score: float | None = None
+    bm25_rank: int | None = None
+    dense_rank: int | None = None
+
+
+class ClauseRetrievalResult(BaseModel):
+    bm25: list[RetrievalHit]
+    dense: list[RetrievalHit]
+    rrf: list[RetrievalHit]
+
+
+class ClauseRetrieval(BaseModel):
+    index: int
+    clause: str
+    expansion: ClauseQueryExpansion
+    retrieval_payload: dict[str, Any]
+    retrieval_results: ClauseRetrievalResult
+
+
+class RetrievalResponse(BaseModel):
+    contract: LeaseContract
+    clauses: list[ClauseRetrieval]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 4단계: reranking  (retrieval 결과 + 문서 내용 포함)
+# ──────────────────────────────────────────────────────────────────────
+
+class RankedDocument(BaseModel):
+    rank: int
+    doc_id: str
+    source_type: str          # "law" | "precedent"
+    rrf_score: float
+    bm25_rank: int | None = None
+    dense_rank: int | None = None
+    # 문서 내용 (DB에서 조회)
+    title: str                # 법령명+조항 or 사건명
+    content: str              # child_text or judgment_summary
+
+
+class ClauseRanking(BaseModel):
+    index: int
+    clause: str
+    top_results: list[RankedDocument]
+
+
+class RerankingResponse(BaseModel):
+    contract: LeaseContract
+    clauses: list[ClauseRanking]

--- a/frontend/app/analysis/page.tsx
+++ b/frontend/app/analysis/page.tsx
@@ -8,97 +8,210 @@ import { PrecedentSection } from "@/components/analysis/PrecedentSection";
 import { BottomActionBar } from "@/components/analysis/BottomActionBar";
 import type { LawItem } from "@/components/analysis/LawSection";
 import type { PrecedentItem } from "@/components/analysis/PrecedentSection";
+import { Loader2, AlertCircle } from "lucide-react";
 
-/* ─── Mock data (실제 API 연동 전 표시용) ─────────────────────────── */
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
 
-const MOCK_LAWS: LawItem[] = [
-  {
-    rank: 1,
-    name: "민법 제635조 (기간의 약정없는 임대차의 해지통고)",
-  },
-  {
-    rank: 2,
-    name: "주택임대차보호법 제6조의2 (묵시적 갱신의 경우 계약의 해지)",
-    warning: "해당 법령에 대한 위법 사항이 있습니다. 즉각 조치가 필요합니다.",
-    detail:
-      "계약서 제3조 2항의 해지 효력 발생 기간(1개월)이 강행규정인 주택임대차보호법 제6조의2 제2항(3개월)에 위배되어 임차인에게 불리하므로 무효임.",
-  },
-];
-
-const MOCK_PRECEDENTS: PrecedentItem[] = [
-  {
-    title: "대법원 2021.X.X. 선고 2020다XXXXX 판결",
-    tags: ["#묵시적갱신", "#해지통고", "#임대차보호법"],
-    facts: [
-      {
-        label: "핵심충돌",
-        text: "묵시적 갱신 시 해지권 행사 시점의 효력 발생 여부.",
-      },
-      {
-        label: "결과",
-        text: "원고 승소 - 해지 통고 후 3개월 경과 시 효력 발생. 강행 규정에 반하는 특약은 무효임을 확인",
-      },
-    ],
-    guide: [
-      { id: "g1", text: "확인사항: 계약서 3조 2항 검토 완료", checked: true },
-      { id: "g2", text: "누락된 사항: 강행규정 위반 시 효력에 대한 조항 부재", checked: false },
-      { id: "g3", text: "모호한 어휘: '언제든지' 라는 표현의 구체화 필요", checked: false },
-      { id: "g4", text: "수치 확인: 해지 효력 발생 기간 (1개월 → 3개월) 수정 요망", checked: false },
-    ],
-  },
-];
-
-const MOCK_ARTICLES = [
-  { title: "제 1 조", items: ["본 계약은 임대인과 임차인 간의 주택 임대차에 관한 권리와 의무를 규정함을 목적으로 한다."] },
-  { title: "제 2조", items: ["임대차 기간은 2024년 1월 1일부터 2026년 12월 31일까지 (24개월)로 한다."] },
-  {
-    title: "제 3조",
-    items: [
-      "① 임대인 또는 임차인이 임대차기간이 끝나기 6개월 전부터 2개월 전까지의 기간에 서로에게 갱신거절의 통지를 하지 아니하거나 계약조건을 변경하지 아니하면 갱신하지 아니한다는 뜻의 통지를 하지 아니한 경우에는 그 기간이 끝난 때에 전 임대차와 동일한 조건으로 다시 임대차한 것으로 본다.",
-      "② 제 1항의 경우 임대차의 존속기간은 2년으로 본다. 단, 임차인은 언제든지 임대인에게 계약해지를 통지할 수 있으며, 이 경우 통지가 임대인에게 도달한 날부터 1개월이 경과하면 그 효력이 발생한다.",
-    ],
-  },
-  {
-    title: "제 5 조 (특약사항)",
-    items: [
-      "① 부동산의 소유권등기시 은행업무 처리기간 확인 후 그 기간동안 임차인은 전출하여야 한다. 이때 근저당 원금 3.9억원 이외의 권리변동(추가 근저당 및 압류등)시 임대인이 손해배상하고, 임차인의 전출 불이행으로 인해 임대인의 손해 발생 시 임차인이 손해배상하기로 한다.",
-      "② 임차인은 계약종료 3개월전 임대인에 갱신을 요구하면 임대인은 최대한 협조한다",
-      "③ 임대인은 본 부동산에 계약일부터 계약종료일까지 추가 권리(근저당권, 압류, 가압류, 가처분 등)를 설정하지 않는다. 이를 1개월 이내 해결하지 못할 시 계약을 해지하고 보증금 반환과 별도로 계약금에 준하는 손해배상금을 임차인에게 지급한다.",
-    ],
-  },
-];
+type ClauseResult = {
+  laws: LawItem[];
+  precedents: PrecedentItem[];
+  status: "loading" | "done" | "error";
+};
 
 /* ─── Page ─────────────────────────────────────────────────────────── */
 
 export default function AnalysisPage() {
-  const [fileName, setFileName] = useState<string>("공덕동_주택 임대차계약서.pdf");
+  const [fileName, setFileName] = useState<string>("계약서 분석 중...");
+  const [generalTerms, setGeneralTerms] = useState<{title: string, text: string}[]>([]);
+  const [specialTerms, setSpecialTerms] = useState<string[]>([]);
+  const [clauseResults, setClauseResults] = useState<Record<number, ClauseResult>>({});
+  const [analysisStatus, setAnalysisStatus] = useState<"loading" | "done">("loading");
+  const [completedCount, setCompletedCount] = useState(0);
 
   useEffect(() => {
-    const stored = sessionStorage.getItem("ade.analysis.fileName");
-    if (stored) setFileName(stored);
+    const storedFileName = sessionStorage.getItem("ade.analysis.fileName");
+    const storedDocId = sessionStorage.getItem("ade.analysis.docId");
+    const storedContract = sessionStorage.getItem("ade.analysis.contract");
+    const clientId = localStorage.getItem("ade.client_id");
+
+    if (storedFileName) setFileName(storedFileName);
+    
+    if (storedContract && storedDocId && clientId) {
+      try {
+        const contract = JSON.parse(storedContract);
+        
+        // 1. 일반 조항 추출
+        const gTerms = [];
+        if (contract.general_terms) {
+          for (let i = 1; i <= 13; i++) {
+            const artKey = `art${i}`;
+            if (contract.general_terms[artKey] && contract.general_terms[artKey].text) {
+              gTerms.push({
+                title: `제 ${i} 조`,
+                text: contract.general_terms[artKey].text
+              });
+            }
+          }
+        }
+        setGeneralTerms(gTerms);
+
+        // 2. 분석할 특약 필터링 및 초기 상태 설정
+        const terms = contract.special_terms.filter((t: string) => t.trim().length > 0);
+        setSpecialTerms(terms);
+
+        const initialResults: Record<number, ClauseResult> = {};
+        terms.forEach((_: string, i: number) => {
+          initialResults[i] = { laws: [], precedents: [], status: "loading" };
+        });
+        setClauseResults(initialResults);
+
+        if (terms.length === 0) {
+          setAnalysisStatus("done");
+          return;
+        }
+
+        // 3. 병렬 분석 실행
+        terms.forEach(async (termText: string, index: number) => {
+          try {
+            const res = await fetch(`${API_BASE}/api/analyze/clause`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                client_id: clientId,
+                doc_id: storedDocId,
+                clause_index: index,
+                clause_text: termText
+              }),
+            });
+
+            if (res.ok) {
+              const data = await res.json();
+              const termLaws: LawItem[] = [];
+              const termPrecedents: PrecedentItem[] = [];
+
+              data.top_results.forEach((doc: any) => {
+                if (doc.source_type === "law") {
+                  termLaws.push({
+                    rank: termLaws.length + 1,
+                    name: doc.title,
+                    detail: doc.content
+                  });
+                } else if (doc.source_type === "precedent") {
+                  termPrecedents.push({
+                    title: doc.title,
+                    tags: ["#관련판례"],
+                    facts: [{ label: "판결 요지", text: doc.content }],
+                    guide: []
+                  });
+                }
+              });
+
+              setClauseResults(prev => ({
+                ...prev,
+                [index]: { laws: termLaws, precedents: termPrecedents, status: "done" }
+              }));
+            } else {
+              setClauseResults(prev => ({ ...prev, [index]: { ...prev[index], status: "error" } }));
+            }
+          } catch (err) {
+            console.error(`특약 ${index} 분석 에러:`, err);
+            setClauseResults(prev => ({ ...prev, [index]: { ...prev[index], status: "error" } }));
+          } finally {
+            setCompletedCount(prev => {
+              const next = prev + 1;
+              if (next === terms.length) setAnalysisStatus("done");
+              return next;
+            });
+          }
+        });
+
+      } catch (e) {
+        console.error("데이터 파싱 오류", e);
+        setAnalysisStatus("done");
+      }
+    } else {
+      setAnalysisStatus("done");
+    }
   }, []);
+
+  const handleTermClick = (index: number) => {
+    const element = document.getElementById(`analysis-result-${index}`);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  };
 
   return (
     <div className="flex flex-col h-screen overflow-hidden" style={{ background: "#F4F3F7" }}>
       <TopNavBar
         mode="analysis"
-        fileName={fileName}
-        analysisStatus="done"
+        fileName={`${fileName} ${specialTerms.length > 0 && analysisStatus === "loading" ? `(분석 중: ${completedCount}/${specialTerms.length})` : ""}`}
+        analysisStatus={analysisStatus}
         activeTab="analysis"
       />
 
-      {/* Split view */}
       <div className="flex flex-row flex-1 min-h-0">
-        {/* Left: Document */}
-        <DocumentPanel articles={MOCK_ARTICLES} />
+        <DocumentPanel 
+          specialTerms={specialTerms}
+          generalTerms={generalTerms}
+          onTermClick={handleTermClick}
+        />
 
-        {/* Right: Analysis results */}
         <section
-          className="flex flex-col flex-1 overflow-y-auto"
-          style={{ background: "#FAF9FD", padding: "32px 32px 128px", gap: "32px" }}
+          className="flex flex-col flex-1 overflow-y-auto px-8 py-8 gap-8"
+          style={{ background: "#FAF9FD", paddingBottom: "128px" }}
         >
-          <LawSection laws={MOCK_LAWS} />
-          <PrecedentSection precedents={MOCK_PRECEDENTS} />
+          {specialTerms.length > 0 ? (
+            specialTerms.map((term, idx) => (
+              <div 
+                key={idx} 
+                id={`analysis-result-${idx}`}
+                className="flex flex-col gap-6 p-6 rounded-xl border bg-white shadow-sm scroll-mt-4"
+                style={{ borderColor: "#E2E8F0" }}
+              >
+                {/* 특약 헤더 */}
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs font-bold text-blue-600 uppercase tracking-wider">특약 {idx + 1} 분석 결과</span>
+                    <h4 className="text-base font-semibold text-gray-900 leading-relaxed">
+                      "{term}"
+                    </h4>
+                  </div>
+                  {clauseResults[idx]?.status === "loading" && (
+                    <div className="flex items-center gap-2 text-sm text-blue-500 font-medium bg-blue-50 px-3 py-1.5 rounded-full">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      분석 중
+                    </div>
+                  )}
+                  {clauseResults[idx]?.status === "error" && (
+                    <div className="flex items-center gap-2 text-sm text-red-500 font-medium bg-red-50 px-3 py-1.5 rounded-full">
+                      <AlertCircle className="h-4 w-4" />
+                      분석 실패
+                    </div>
+                  )}
+                </div>
+
+                {/* 분석 결과 (로딩 완료 시에만) */}
+                {clauseResults[idx]?.status !== "loading" && (
+                  <div className="flex flex-col gap-8 pt-4 border-t border-gray-100">
+                    {clauseResults[idx].laws.length > 0 ? (
+                      <LawSection laws={clauseResults[idx].laws} />
+                    ) : (
+                      <p className="text-sm text-gray-400 italic">관련 법령을 찾지 못했습니다.</p>
+                    )}
+                    
+                    {clauseResults[idx].precedents.length > 0 && (
+                      <PrecedentSection precedents={clauseResults[idx].precedents} />
+                    )}
+                  </div>
+                )}
+              </div>
+            ))
+          ) : (
+            <div className="flex items-center justify-center h-64 text-gray-500 border border-dashed rounded-xl">
+              분석할 특약사항이 없습니다.
+            </div>
+          )}
         </section>
       </div>
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { v4 as uuidv4 } from "uuid";
 import { TopNavBar } from "@/components/TopNavBar";
 import type { NavTab } from "@/components/TopNavBar";
 import { UploadDropzone } from "@/components/UploadDropzone";
@@ -13,8 +14,21 @@ export default function UploadPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [activeTab, setActiveTab] = useState<NavTab>("analysis");
+  const [clientId, setClientId] = useState<string>("");
+
+  // 컴포넌트 마운트 시 client_id 초기화
+  useEffect(() => {
+    let storedId = localStorage.getItem("ade.client_id");
+    if (!storedId) {
+      storedId = uuidv4();
+      localStorage.setItem("ade.client_id", storedId);
+    }
+    setClientId(storedId);
+  }, []);
 
   async function handleFileSelect(file: File) {
+    if (!clientId) return;
+
     setFileName(file.name);
     setIsLoading(true);
     setError(undefined);
@@ -22,8 +36,10 @@ export default function UploadPage() {
     try {
       const form = new FormData();
       form.append("file", file);
+      form.append("client_id", clientId);
 
-      const res = await fetch(`${API_BASE}/v1/contracts/analyze/sync`, {
+      // 1. 새로운 파싱 전용 API 호출
+      const res = await fetch(`${API_BASE}/api/documents`, {
         method: "POST",
         body: form,
       });
@@ -34,9 +50,13 @@ export default function UploadPage() {
       }
 
       const data = await res.json();
-      sessionStorage.setItem("ade.analysis.result", JSON.stringify(data));
+      
+      // 2. 파싱된 계약서 정보와 메타데이터 저장
+      sessionStorage.setItem("ade.analysis.docId", data.doc_id);
+      sessionStorage.setItem("ade.analysis.contract", JSON.stringify(data.contract));
       sessionStorage.setItem("ade.analysis.fileName", file.name);
 
+      // 3. 분석 페이지로 이동
       window.location.href = "/analysis";
     } catch (e) {
       setError(e instanceof Error ? e.message : "알 수 없는 오류가 발생했습니다.");

--- a/frontend/components/RecentDocumentPanel.tsx
+++ b/frontend/components/RecentDocumentPanel.tsx
@@ -1,21 +1,31 @@
 "use client";
 
-import { ChevronRight } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ChevronRight, FileText, Loader2 } from "lucide-react";
 
-type Document = {
-  id: string;
-  name: string;
-  date: string;
-  size: string;
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
+
+type DocumentHistoryItem = {
+  doc_id: string;
+  file_name: string;
+  created_at: string;
 };
 
-const MOCK_DOCUMENTS: Document[] = [
-  { id: "1", name: "공덕동_임대차계약서.pdf", date: "Oct 25, 2026", size: "2.4 MB" },
-  { id: "2", name: "성북동_임대차계약서(1).docx", date: "Oct 22, 2026", size: "1.1 MB" },
-  { id: "3", name: "이사할_집_계약서.pdf", date: "Oct 20, 2026", size: "845 KB" },
-];
+function RecentDocumentCard({ 
+  doc, 
+  onSelect,
+  isSelecting 
+}: { 
+  doc: DocumentHistoryItem; 
+  onSelect: (doc: DocumentHistoryItem) => void;
+  isSelecting: boolean;
+}) {
+  const dateStr = new Date(doc.created_at).toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 
-function RecentDocumentCard({ doc }: { doc: Document }) {
   return (
     <article
       className="rounded-lg border p-4 shadow-sm transition"
@@ -30,40 +40,37 @@ function RecentDocumentCard({ doc }: { doc: Document }) {
         (e.currentTarget as HTMLElement).style.borderColor = "#E2E8F0";
       }}
     >
-      <h4
-        className="text-sm font-medium leading-snug"
-        style={{ color: "#1A1C1E", fontFamily: "var(--font-public-sans)" }}
-      >
-        {doc.name}
-      </h4>
-      <p
-        className="mt-1 text-xs"
-        style={{ color: "#74777F", fontFamily: "var(--font-public-sans)" }}
-      >
-        {doc.date} · {doc.size}
-      </p>
-      <div className="mt-3 flex flex-wrap items-center gap-2">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 rounded bg-blue-50 p-2 text-blue-600">
+          <FileText className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h4
+            className="truncate text-sm font-medium leading-snug"
+            style={{ color: "#1A1C1E", fontFamily: "var(--font-public-sans)" }}
+            title={doc.file_name}
+          >
+            {doc.file_name}
+          </h4>
+          <p
+            className="mt-1 text-xs"
+            style={{ color: "#74777F", fontFamily: "var(--font-public-sans)" }}
+          >
+            {dateStr}
+          </p>
+        </div>
+      </div>
+      
+      <div className="mt-3 flex items-center gap-2">
         <button
           type="button"
-          className="inline-flex items-center gap-1 text-xs font-medium hover:underline"
+          onClick={() => onSelect(doc)}
+          disabled={isSelecting}
+          className="inline-flex items-center gap-1 text-xs font-medium hover:underline disabled:opacity-50"
           style={{ color: "#002045", fontFamily: "var(--font-public-sans)" }}
         >
-          View Analysis
-          <ChevronRight className="h-3.5 w-3.5" aria-hidden />
-        </button>
-        <button
-          type="button"
-          disabled
-          className="rounded-md border px-2.5 py-1 text-xs font-medium opacity-60"
-          style={{
-            background: "#FAF9FD",
-            borderColor: "#E2E8F0",
-            color: "#43474E",
-            fontFamily: "var(--font-public-sans)",
-          }}
-          title="추후 연결 예정"
-        >
-          재분석
+          {isSelecting ? "불러오는 중..." : "결과 보기"}
+          {!isSelecting && <ChevronRight className="h-3.5 w-3.5" aria-hidden />}
         </button>
       </div>
     </article>
@@ -71,6 +78,61 @@ function RecentDocumentCard({ doc }: { doc: Document }) {
 }
 
 export function RecentDocumentPanel() {
+  const [docs, setDocs] = useState<DocumentHistoryItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectingId, setSelectingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchHistory() {
+      const clientId = localStorage.getItem("ade.client_id");
+      if (!clientId) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const res = await fetch(`${API_BASE}/api/documents?client_id=${clientId}`);
+        if (res.ok) {
+          const data = await res.json();
+          setDocs(data.documents);
+        }
+      } catch (err) {
+        console.error("히스토리 로드 실패:", err);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchHistory();
+  }, []);
+
+  async function handleSelect(doc: DocumentHistoryItem) {
+    const clientId = localStorage.getItem("ade.client_id");
+    if (!clientId) return;
+
+    setSelectingId(doc.doc_id);
+    try {
+      // 1. GCS에서 파싱된 데이터 가져오기
+      const res = await fetch(`${API_BASE}/api/documents/${doc.doc_id}?client_id=${clientId}`);
+      if (res.ok) {
+        const contractData = await res.json();
+        
+        // 2. 세션 스토리지에 저장 (분석 페이지에서 사용하도록)
+        sessionStorage.setItem("ade.analysis.docId", doc.doc_id);
+        sessionStorage.setItem("ade.analysis.contract", JSON.stringify(contractData));
+        sessionStorage.setItem("ade.analysis.fileName", doc.file_name);
+
+        // 3. 분석 페이지로 이동
+        window.location.href = "/analysis";
+      } else {
+        throw new Error("데이터 조회 실패");
+      }
+    } catch (err) {
+      alert("문서 데이터를 불러오는 중 오류가 발생했습니다.");
+      setSelectingId(null);
+    }
+  }
+
   return (
     <aside
       className="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto lg:w-[320px] lg:shrink-0 lg:border-l lg:pl-6"
@@ -80,15 +142,33 @@ export function RecentDocumentPanel() {
         className="text-base font-semibold"
         style={{ color: "#1A1C1E", fontFamily: "var(--font-public-sans)" }}
       >
-        최근 문서
+        최근 분석 문서
       </h3>
-      <ul className="flex flex-col gap-3">
-        {MOCK_DOCUMENTS.map((doc) => (
-          <li key={doc.id}>
-            <RecentDocumentCard doc={doc} />
-          </li>
-        ))}
-      </ul>
+      
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+        </div>
+      ) : docs.length > 0 ? (
+        <ul className="flex flex-col gap-3 pb-8">
+          {docs.map((doc) => (
+            <li key={doc.doc_id}>
+              <RecentDocumentCard 
+                doc={doc} 
+                onSelect={handleSelect} 
+                isSelecting={selectingId === doc.doc_id}
+              />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div 
+          className="rounded-lg border border-dashed p-8 text-center text-sm"
+          style={{ color: "#74777F", background: "#FAF9FD" }}
+        >
+          아직 분석한 문서가 없습니다.
+        </div>
+      )}
     </aside>
   );
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,10 +9,12 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@types/uuid": "^10.0.0",
     "lucide-react": "^1.16.0",
     "next": "16.2.6",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
📝 변경 사항
- 병렬 아키텍처 도입: 단일 특약 분석 API(analyze/clause)를 신설하여 프론트엔드에서 완료되는 순서대로 결과를 렌더링하는 구조로 변경했습니다.
- 백그라운드 처리: 문서 업로드 시 GCS 저장 및 DB 기록을 BackgroundTasks로 위임하여 응답 속도를 20초 -> 2초 내외로 단축했습니다.
- 히스토리 시스템: UUID 기반 client_id를 도입하여 로그인 없이도 사용자의 과거 분석 내역을 복구할 수 있는 로직을 구현했습니다.

🔗 관련 이슈
closes #105 

🧪 테스트
- [x] 특약 6개 포함 대용량 PDF 업로드 시 병렬 호출 로그 확인
- [x] 로컬 스토리지 삭제 시 새로운 client_id 생성 및 히스토리 초기화 검증
- [x] GCS에 업로드된 파싱 JSON 파일이 api/documents/{id}로 정확히 서빙되는지 확인

✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 테스트를 추가/수정했습니다.
- [x] 문서를 업데이트했습니다 (API 스키마).

💬 리뷰어에게
app/main.py의 lifespan 내에 print와 traceback을 추가하여 Cloud Run 로그 가시성을 확보했습니다. 이 부분은 운영 모니터링에 큰
도움이 될 것 같습니다.