### PR TITLE
feat(retrieval): alpha_hybrid 리랭킹 + 법령/판례 분리 적용 API쪽 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ tests/pipeline/query_expansion_v1/
 # test
 tests/
 /scripts/db_peek.py
+/scripts/batch_rag_contracts.py

--- a/app/main.py
+++ b/app/main.py
@@ -53,7 +53,7 @@ log = logging.getLogger(__name__)
 # 특약 병렬 처리 스레드 수
 CLAUSE_WORKERS = 4
 # reranking 단계에서 반환할 상위 문서 수
-RERANKING_TOP_N = 5
+RERANKING_TOP_N = 20
 
 _clause_executor = ThreadPoolExecutor(max_workers=CLAUSE_WORKERS, thread_name_prefix="clause")
 
@@ -239,7 +239,8 @@ async def analyze_single_clause(request: AnalyzeClauseRequest) -> ClauseAnalysis
         index=request.clause_index,
         clause=request.clause_text,
         expansion=expansion.expansion,
-        top_results=ranking_res[0].top_results if ranking_res else []
+        law_results=ranking_res[0].law_results if ranking_res else [],
+        prec_results=ranking_res[0].prec_results if ranking_res else [],
     )
 
 # ──────────────────────────────────────────────────────────────────────
@@ -385,61 +386,57 @@ def _retrieve_clause(clause: ClauseExpansion) -> ClauseRetrieval:
         retrieval_results=ClauseRetrievalResult(
             bm25=[RetrievalHit(**h) for h in raw["bm25"]],
             dense=[RetrievalHit(**h) for h in raw["dense"]],
-            rrf=[RetrievalHit(**h) for h in raw["rrf"]],
+            law=[RetrievalHit(**h) for h in raw["law"]],
+            prec=[RetrievalHit(**h) for h in raw["prec"]],
         ),
     )
 
 
 def _rerank_all(clauses: list[ClauseRetrieval]) -> list[ClauseRanking]:
-    """RRF 상위 RERANKING_TOP_N 결과에 문서 내용을 조회해 반환한다."""
-    # 1) 모든 특약의 RRF top-N 결과에서 doc_id 수집
+    """법령/판례 각각 상위 RERANKING_TOP_N 결과에 문서 내용을 조회해 반환한다.
+
+    법령/판례는 독립 랭킹(각자 rank 1~N)이므로 분리하여 반환한다.
+    """
+    # 1) 모든 특약의 법령/판례 top-N 결과에서 doc_id 수집
     law_ids: set[str] = set()
     prec_ids: set[str] = set()
     for clause in clauses:
-        for hit in clause.retrieval_results.rrf[:RERANKING_TOP_N]:
-            if hit.source_type == "law":
-                law_ids.add(hit.doc_id)
-            else:
-                prec_ids.add(hit.doc_id)
+        for hit in clause.retrieval_results.law[:RERANKING_TOP_N]:
+            law_ids.add(hit.doc_id)
+        for hit in clause.retrieval_results.prec[:RERANKING_TOP_N]:
+            prec_ids.add(hit.doc_id)
 
     # 2) 배치 조회
     law_content = _fetch_law_content(list(law_ids))
     prec_content = _fetch_prec_content(list(prec_ids))
 
-    # 3) 결과 조합
+    # 3) 결과 조합 (법령/판례 분리)
     ranked_clauses: list[ClauseRanking] = []
     for clause in clauses:
-        top: list[RankedDocument] = []
-        for hit in clause.retrieval_results.rrf[:RERANKING_TOP_N]:
-            if hit.source_type == "law":
-                doc = law_content.get(hit.doc_id, {})
-                title = (
-                    f"{doc.get('law_name', '')} "
-                    f"제{doc.get('article_no', '')}조"
-                    f"{' 제' + str(doc.get('paragraph_no', '')) + '항' if doc.get('paragraph_no') else ''}"
-                ).strip()
-                
-                parent_txt = doc.get("parent_text") or ""
-                child_txt = doc.get("child_text") or ""
-                
-                # 조항 전체 내용(parent)과 해당 항의 내용(child)을 조합
-                if not parent_txt:
-                    content = child_txt
-                elif child_txt in parent_txt:
-                    content = parent_txt
-                else:
-                    content = f"{parent_txt}\n\n{child_txt}"
-            else:
-                doc = prec_content.get(hit.doc_id, {})
-                title = doc.get("case_name") or hit.doc_id
-                content = doc.get("judgment_summary") or doc.get("issue") or ""
+        law_top: list[RankedDocument] = []
+        for hit in clause.retrieval_results.law[:RERANKING_TOP_N]:
+            doc = law_content.get(hit.doc_id, {})
+            title = (
+                f"{doc.get('law_name', '')} "
+                f"제{doc.get('article_no', '')}조"
+                f"{' 제' + str(doc.get('paragraph_no', '')) + '항' if doc.get('paragraph_no') else ''}"
+            ).strip()
 
-            top.append(
+            parent_txt = doc.get("parent_text") or ""
+            child_txt = doc.get("child_text") or ""
+            if not parent_txt:
+                content = child_txt
+            elif child_txt in parent_txt:
+                content = parent_txt
+            else:
+                content = f"{parent_txt}\n\n{child_txt}"
+
+            law_top.append(
                 RankedDocument(
                     rank=hit.rank,
                     doc_id=hit.doc_id,
                     source_type=hit.source_type,
-                    rrf_score=hit.rrf_score or 0.0,
+                    hybrid_score=hit.hybrid_score or 0.0,
                     bm25_rank=hit.bm25_rank,
                     dense_rank=hit.dense_rank,
                     title=title,
@@ -447,7 +444,33 @@ def _rerank_all(clauses: list[ClauseRetrieval]) -> list[ClauseRanking]:
                 )
             )
 
-        ranked_clauses.append(ClauseRanking(index=clause.index, clause=clause.clause, top_results=top))
+        prec_top: list[RankedDocument] = []
+        for hit in clause.retrieval_results.prec[:RERANKING_TOP_N]:
+            doc = prec_content.get(hit.doc_id, {})
+            title = doc.get("case_name") or hit.doc_id
+            content = doc.get("judgment_summary") or doc.get("issue") or ""
+
+            prec_top.append(
+                RankedDocument(
+                    rank=hit.rank,
+                    doc_id=hit.doc_id,
+                    source_type=hit.source_type,
+                    hybrid_score=hit.hybrid_score or 0.0,
+                    bm25_rank=hit.bm25_rank,
+                    dense_rank=hit.dense_rank,
+                    title=title,
+                    content=content,
+                )
+            )
+
+        ranked_clauses.append(
+            ClauseRanking(
+                index=clause.index,
+                clause=clause.clause,
+                law_results=law_top,
+                prec_results=prec_top,
+            )
+        )
 
     return ranked_clauses
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -50,7 +50,8 @@ class ClauseAnalysisResponse(BaseModel):
     index: int
     clause: str
     expansion: ClauseQueryExpansion
-    top_results: list[RankedDocument]
+    law_results: list[RankedDocument]   # 법령 (rank 1~TOP_K, 독립)
+    prec_results: list[RankedDocument]  # 판례 (rank 1~TOP_K, 독립)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -86,7 +87,7 @@ class RetrievalHit(BaseModel):
     doc_id: str
     source_type: str          # "law" | "precedent"
     rank: int
-    rrf_score: float | None = None
+    hybrid_score: float | None = None
     bm25_rank: int | None = None
     dense_rank: int | None = None
 
@@ -94,7 +95,8 @@ class RetrievalHit(BaseModel):
 class ClauseRetrievalResult(BaseModel):
     bm25: list[RetrievalHit]
     dense: list[RetrievalHit]
-    rrf: list[RetrievalHit]
+    law: list[RetrievalHit]   # alpha hybrid 법령 (rank 1~TOP_K, 독립)
+    prec: list[RetrievalHit]  # alpha hybrid 판례 (rank 1~TOP_K, 독립)
 
 
 class ClauseRetrieval(BaseModel):
@@ -118,7 +120,7 @@ class RankedDocument(BaseModel):
     rank: int
     doc_id: str
     source_type: str          # "law" | "precedent"
-    rrf_score: float
+    hybrid_score: float
     bm25_rank: int | None = None
     dense_rank: int | None = None
     # 문서 내용 (DB에서 조회)
@@ -129,7 +131,8 @@ class RankedDocument(BaseModel):
 class ClauseRanking(BaseModel):
     index: int
     clause: str
-    top_results: list[RankedDocument]
+    law_results: list[RankedDocument]   # 법령 (rank 1~TOP_K, 독립)
+    prec_results: list[RankedDocument]  # 판례 (rank 1~TOP_K, 독립)
 
 
 class RerankingResponse(BaseModel):

--- a/frontend/app/analysis/page.tsx
+++ b/frontend/app/analysis/page.tsx
@@ -89,21 +89,21 @@ export default function AnalysisPage() {
               const termLaws: LawItem[] = [];
               const termPrecedents: PrecedentItem[] = [];
 
-              data.top_results.forEach((doc: any) => {
-                if (doc.source_type === "law") {
-                  termLaws.push({
-                    rank: termLaws.length + 1,
-                    name: doc.title,
-                    detail: doc.content
-                  });
-                } else if (doc.source_type === "precedent") {
-                  termPrecedents.push({
-                    title: doc.title,
-                    tags: ["#관련판례"],
-                    facts: [{ label: "판결 요지", text: doc.content }],
-                    guide: []
-                  });
-                }
+              (data.law_results ?? []).forEach((doc: any) => {
+                termLaws.push({
+                  rank: termLaws.length + 1,
+                  name: doc.title,
+                  detail: doc.content
+                });
+              });
+
+              (data.prec_results ?? []).forEach((doc: any) => {
+                termPrecedents.push({
+                  title: doc.title,
+                  tags: ["#관련판례"],
+                  facts: [{ label: "판결 요지", text: doc.content }],
+                  guide: []
+                });
               });
 
               setClauseResults(prev => ({

--- a/pipeline/retrieval/retrieval_service.py
+++ b/pipeline/retrieval/retrieval_service.py
@@ -3,13 +3,17 @@
 Dense 유사도 검색은 in-memory numpy 대신 PostgreSQL pgvector (<=> 코사인 거리)에 위임한다.
 → load() 시 임베딩 벡터를 메모리에 올리지 않아 RAM 사용량이 대폭 줄어든다.
 
+리랭킹 방식: alpha_hybrid
+  - 법령:  α=0.20 → BM25 20% + Dense 80%  (Dense 위주 — 의미 기반)
+  - 판례:  α=0.70 → BM25 70% + Dense 30%  (BM25 위주 — 키워드 기반)
+  - 법령/판례 각각 독립 랭킹 후 합산 → 두 도메인 결과 보장
+
+alpha 값은 alpha_sweep 평가 최적값 (alpha_sweep_2d_20260530_235115) 사용.
+
 의존 관계:
   BM25  : pipeline.retrieval.bm25_retrieval (tokenize, build_query_tokens, load_*_from_db)
   Embed : pipeline.retrieval.dense_retrieval (embed_query — Vertex AI 호출)
   DB    : shared.db.connection (pgvector 쿼리)
-
-무거운 import (Kiwi NLP 모델, Vertex AI init 등)는 load() / retrieve() 내부에서
-지연 임포트하여 uvicorn 포트 바인딩 전에 실행되지 않도록 한다.
 """
 from __future__ import annotations
 
@@ -17,11 +21,12 @@ import logging
 
 log = logging.getLogger(__name__)
 
-TOP_K = 20
-RRF_K = 60
+TOP_K      = 20   # 법령/판례 각각 상위 K개 → 총 최대 2*TOP_K 반환
+ALPHA_LAW  = 0.20  # 법령: BM25 20% + Dense 80%
+ALPHA_PREC = 0.70  # 판례: BM25 70% + Dense 30%
+
 # pgvector <=> 는 (1 - cosine_similarity) 를 반환한다.
-# MIN_COSINE_SIMILARITY = 0.2 이면 최대 허용 distance = 0.8
-_MIN_SIM = 0.2
+_MIN_SIM  = 0.2
 _MAX_DIST = round(1.0 - _MIN_SIM, 6)  # 0.8
 
 
@@ -35,7 +40,6 @@ class RetrievalService:
 
     @property
     def is_ready(self) -> bool:
-        """코퍼스 로드 완료 여부."""
         return self._corpus is not None
 
     @property
@@ -63,7 +67,7 @@ class RetrievalService:
 
         log.info("▶ BM25 코퍼스 로드 시작...")
 
-        law_df = load_law_child_from_db()
+        law_df  = load_law_child_from_db()
         prec_df = load_case_law_from_db()
 
         law_docs = [
@@ -80,49 +84,122 @@ class RetrievalService:
             len(law_docs),
             len(prec_docs),
         )
-        law_bm25 = BM25Okapi([tokenize(d["text"]) for d in law_docs])
+        law_bm25  = BM25Okapi([tokenize(d["text"]) for d in law_docs])
         prec_bm25 = BM25Okapi([tokenize(d["text"]) for d in prec_docs])
 
         self._corpus = {
-            "law_docs": law_docs,
-            "law_bm25": law_bm25,
+            "law_docs":  law_docs,
+            "law_bm25":  law_bm25,
             "prec_docs": prec_docs,
             "prec_bm25": prec_bm25,
         }
         log.info("▶ BM25 코퍼스 로드 완료 (Dense 검색은 쿼리 시 pgvector에 위임)")
 
     # ------------------------------------------------------------------ #
-    # Dense 검색 (pgvector)                                               #
+    # 하이브리드 검색 (BM25 + Dense → Alpha Hybrid)                       #
     # ------------------------------------------------------------------ #
 
-    def _pgvector_search(
-        self,
-        query_vec,  # np.ndarray
-        top_k: int,
-    ) -> dict[str, tuple[int, str]]:
-        """pgvector <=> (코사인 거리)로 법령·판례를 각각 검색한다.
+    def retrieve(self, payload: dict) -> dict:
+        """BM25 → Dense(pgvector) → Alpha Hybrid 실행.
 
-        반환값: {doc_id: (rank, source_type)}
-          - doc_id  : clause_key(법령) 또는 case_number(판례) 문자열
-          - rank    : 1-based 순위 (거리 오름차순)
-          - source_type: "law" | "precedent"
+        Parameters
+        ----------
+        payload:
+            build_retrieval_payload() 결과.
+            필수 키: "bm25_keywords" (list[str]), "dense_query" (str)
 
-        vec_literal은 numpy float 값만으로 구성된 문자열이므로 SQL 인젝션 위험 없음.
-        pg8000 드라이버는 pgvector 타입 어댑터를 지원하지 않아 문자열 리터럴로 캐스팅한다.
+        Returns
+        -------
+        dict with keys:
+            "bm25" : BM25 순위 목록
+            "dense": Dense 순위 목록
+            "law"  : Alpha Hybrid 법령 순위 목록 (rank 1~TOP_K, 독립)
+            "prec" : Alpha Hybrid 판례 순위 목록 (rank 1~TOP_K, 독립)
+
+        법령/판례는 평가(legal_retrieval_eval_multi)와 동일하게 각각 독립 랭킹한다.
+        슬롯 경쟁 없이 두 도메인 모두 top-K를 보장한다.
         """
-        from sqlalchemy import text
+        from pipeline.retrieval.bm25_retrieval import build_query_tokens
+        from pipeline.retrieval.dense_retrieval import embed_query
 
+        corpus = self.corpus
+
+        # ── BM25 (법령/판례 각각, raw score 포함) ─────────────────────
+        query_tokens = build_query_tokens(payload["bm25_keywords"])
+
+        bm25_law_scores  = self._bm25_scores(query_tokens, corpus["law_bm25"],  corpus["law_docs"],  "law",       "clause_key")
+        bm25_prec_scores = self._bm25_scores(query_tokens, corpus["prec_bm25"], corpus["prec_docs"], "precedent", "case_number")
+
+        # ── Dense (pgvector, similarity score 포함) ───────────────────
+        query_vec = embed_query(payload["dense_query"], "embed_vertex")
+        dense_law_scores, dense_prec_scores = self._pgvector_scores(query_vec, TOP_K * 2)
+
+        # ── Min-Max 정규화 (평가와 동일: 법령+판례 합친 풀에서 정규화) ──
+        # 법령 id(clause_key)와 판례 id(case_number)는 ID 공간이 달라 충돌 없음.
+        bm25_raw_all  = {d: s for d, (_, __, s) in {**bm25_law_scores,  **bm25_prec_scores}.items()}
+        dense_raw_all = {d: s for d, (_, __, s) in {**dense_law_scores, **dense_prec_scores}.items()}
+        norm_bm25  = self._minmax(bm25_raw_all)
+        norm_dense = self._minmax(dense_raw_all)
+
+        # ── Alpha Hybrid (법령/판례 독립 랭킹, 각자 rank 1~TOP_K) ──────
+        law_results  = self._alpha_hybrid(bm25_law_scores,  dense_law_scores,  norm_bm25, norm_dense, ALPHA_LAW,  "law",       TOP_K)
+        prec_results = self._alpha_hybrid(bm25_prec_scores, dense_prec_scores, norm_bm25, norm_dense, ALPHA_PREC, "precedent", TOP_K)
+
+        # BM25 / Dense 결과 목록 (디버깅/검증용)
+        bm25_list = sorted(
+            [{"doc_id": d, "source_type": st, "rank": r}
+             for d, (r, st, _) in {**bm25_law_scores, **bm25_prec_scores}.items()],
+            key=lambda x: x["rank"],
+        )
+        dense_list = sorted(
+            [{"doc_id": d, "source_type": st, "rank": r}
+             for d, (r, st, _) in {**dense_law_scores, **dense_prec_scores}.items()],
+            key=lambda x: x["rank"],
+        )
+
+        return {"bm25": bm25_list, "dense": dense_list, "law": law_results, "prec": prec_results}
+
+    # ------------------------------------------------------------------ #
+    # BM25 점수 수집                                                       #
+    # ------------------------------------------------------------------ #
+
+    def _bm25_scores(
+        self,
+        query_tokens: list[str],
+        bm25,
+        docs: list[dict],
+        source_type: str,
+        id_field: str,
+    ) -> dict[str, tuple[int, str, float]]:
+        """doc_id → (rank, source_type, raw_score) 반환."""
+        scores  = bm25.get_scores(query_tokens)
+        top_idx = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:TOP_K * 2]
+        return {
+            docs[idx][id_field]: (rank, source_type, float(scores[idx]))
+            for rank, idx in enumerate(top_idx, 1)
+        }
+
+    # ------------------------------------------------------------------ #
+    # Dense 점수 수집 (pgvector)                                          #
+    # ------------------------------------------------------------------ #
+
+    def _pgvector_scores(
+        self,
+        query_vec,
+        top_k: int,
+    ) -> tuple[dict[str, tuple[int, str, float]], dict[str, tuple[int, str, float]]]:
+        """법령/판례 각각 doc_id → (rank, source_type, similarity) 반환."""
+        from sqlalchemy import text
         from shared.db.connection import get_db_client
 
-        # numpy ndarray → '[f0,f1,...,fn]' 문자열
         vec_literal = "[" + ",".join(str(float(x)) for x in query_vec) + "]"
-        max_dist = _MAX_DIST
-
-        db = get_db_client()
+        max_dist    = _MAX_DIST
+        db          = get_db_client()
 
         law_rows = db.fetch_all(
             text(f"""
-                SELECT clause_key::text AS doc_id
+                SELECT clause_key::text AS doc_id,
+                       1.0 - (embed_vertex <=> '{vec_literal}'::vector) AS similarity
                 FROM   law_child
                 WHERE  embed_vertex IS NOT NULL
                   AND  embed_vertex <=> '{vec_literal}'::vector <= {max_dist}
@@ -134,7 +211,8 @@ class RetrievalService:
 
         prec_rows = db.fetch_all(
             text(f"""
-                SELECT case_number::text AS doc_id
+                SELECT case_number::text AS doc_id,
+                       1.0 - (embed_vertex <=> '{vec_literal}'::vector) AS similarity
                 FROM   case_law
                 WHERE  embed_vertex IS NOT NULL
                   AND  embed_vertex <=> '{vec_literal}'::vector <= {max_dist}
@@ -144,112 +222,59 @@ class RetrievalService:
             {"top_k": top_k},
         )
 
-        hits: dict[str, tuple[int, str]] = {}
-        for rank, row in enumerate(law_rows, 1):
-            hits[str(row["doc_id"])] = (rank, "law")
-        for rank, row in enumerate(prec_rows, 1):
-            doc_id = str(row["doc_id"])
-            # 동일 doc_id가 두 테이블에 겹칠 일은 없지만 방어적으로 처리
-            if doc_id not in hits or rank < hits[doc_id][0]:
-                hits[doc_id] = (rank, "precedent")
+        law_scores  = {str(r["doc_id"]): (rank, "law",       float(r["similarity"])) for rank, r in enumerate(law_rows,  1)}
+        prec_scores = {str(r["doc_id"]): (rank, "precedent", float(r["similarity"])) for rank, r in enumerate(prec_rows, 1)}
 
-        log.debug(
-            "  pgvector 결과: 법령 %d건, 판례 %d건",
-            len(law_rows),
-            len(prec_rows),
-        )
-        return hits
+        return law_scores, prec_scores
 
     # ------------------------------------------------------------------ #
-    # 하이브리드 검색 (BM25 + Dense → RRF)                                #
+    # Alpha Hybrid 융합                                                    #
     # ------------------------------------------------------------------ #
 
-    def retrieve(self, payload: dict) -> dict:
-        """BM25 → Dense(pgvector) → RRF 실행.
+    @staticmethod
+    def _minmax(scores: dict[str, float]) -> dict[str, float]:
+        if not scores:
+            return {}
+        lo, hi = min(scores.values()), max(scores.values())
+        if hi == lo:
+            return {k: 0.0 for k in scores}
+        return {k: (v - lo) / (hi - lo) for k, v in scores.items()}
 
-        Parameters
-        ----------
-        payload:
-            build_retrieval_payload() 결과.
-            필수 키: "bm25_keywords" (list[str]), "dense_query" (str)
+    def _alpha_hybrid(
+        self,
+        bm25_scores:  dict[str, tuple[int, str, float]],
+        dense_scores: dict[str, tuple[int, str, float]],
+        norm_bm25:  dict[str, float],
+        norm_dense: dict[str, float],
+        alpha: float,
+        source_type: str,
+        top_k: int,
+    ) -> list[dict]:
+        """alpha * norm_bm25 + (1-alpha) * norm_dense 로 융합 후 상위 top_k 반환.
 
-        Returns
-        -------
-        dict with keys:
-            "bm25"  : BM25 순위 목록
-            "dense" : Dense 순위 목록
-            "rrf"   : RRF 융합 순위 목록
-        각 항목: {"doc_id", "source_type", "rank", ...}
+        norm_bm25/norm_dense 는 법령+판례 합친 풀에서 이미 정규화된 값(평가와 동일).
+        이 도메인(source_type)에 속한 doc_id 들만 골라 랭킹한다.
         """
-        from pipeline.retrieval.bm25_retrieval import build_query_tokens
-        from pipeline.retrieval.dense_retrieval import embed_query
+        all_ids = set(bm25_scores) | set(dense_scores)
+        scored  = []
+        for doc_id in all_ids:
+            nb     = norm_bm25.get(doc_id,  0.0)
+            nd     = norm_dense.get(doc_id, 0.0)
+            hybrid = alpha * nb + (1.0 - alpha) * nd
+            scored.append({
+                "doc_id":       doc_id,
+                "source_type":  source_type,
+                "rank":         0,
+                "hybrid_score": round(hybrid, 6),
+                "bm25_rank":    bm25_scores[doc_id][0]  if doc_id in bm25_scores  else None,
+                "dense_rank":   dense_scores[doc_id][0] if doc_id in dense_scores else None,
+            })
 
-        corpus = self.corpus
-
-        # ── BM25 ──────────────────────────────────────────────────────
-        query_tokens = build_query_tokens(payload["bm25_keywords"])
-        bm25_hits: dict[str, tuple[int, str]] = {}
-        for docs, bm25, source_type, id_field in [
-            (corpus["law_docs"], corpus["law_bm25"], "law", "clause_key"),
-            (corpus["prec_docs"], corpus["prec_bm25"], "precedent", "case_number"),
-        ]:
-            scores = bm25.get_scores(query_tokens)
-            top_idx = sorted(
-                range(len(scores)), key=lambda i: scores[i], reverse=True
-            )[:TOP_K]
-            for rank, idx in enumerate(top_idx, 1):
-                bm25_hits[docs[idx][id_field]] = (rank, source_type)
-
-        # ── Dense (pgvector) ──────────────────────────────────────────
-        query_vec = embed_query(payload["dense_query"], "embed_vertex")
-        dense_hits = self._pgvector_search(query_vec, TOP_K)
-
-        # ── RRF ───────────────────────────────────────────────────────
-        scored = []
-        for doc_id in set(bm25_hits) | set(dense_hits):
-            b_rank = bm25_hits[doc_id][0] if doc_id in bm25_hits else 1000
-            d_rank = dense_hits[doc_id][0] if doc_id in dense_hits else 1000
-            source_type = (bm25_hits.get(doc_id) or dense_hits.get(doc_id))[1]
-            scored.append(
-                {
-                    "doc_id": doc_id,
-                    "source_type": source_type,
-                    "rrf_score": round(
-                        1 / (RRF_K + b_rank) + 1 / (RRF_K + d_rank), 6
-                    ),
-                    "bm25_rank": b_rank if b_rank != 1000 else None,
-                    "dense_rank": d_rank if d_rank != 1000 else None,
-                }
-            )
-
-        scored.sort(
-            key=lambda x: (
-                -x["rrf_score"],
-                x["bm25_rank"] if x["bm25_rank"] is not None else 1000,
-                x["dense_rank"] if x["dense_rank"] is not None else 1000,
-                x["doc_id"],
-            )
-        )
-        rrf_results = scored[:TOP_K]
-        for rank, item in enumerate(rrf_results, 1):
+        scored.sort(key=lambda x: x["hybrid_score"], reverse=True)
+        top = scored[:top_k]
+        for rank, item in enumerate(top, 1):  # 도메인 내 독립 rank 1~top_k
             item["rank"] = rank
-
-        bm25_results = sorted(
-            [
-                {"doc_id": d, "source_type": st, "rank": r}
-                for d, (r, st) in bm25_hits.items()
-            ],
-            key=lambda x: x["rank"],
-        )
-        dense_results = sorted(
-            [
-                {"doc_id": d, "source_type": st, "rank": r}
-                for d, (r, st) in dense_hits.items()
-            ],
-            key=lambda x: x["rank"],
-        )
-
-        return {"bm25": bm25_results, "dense": dense_results, "rrf": rrf_results}
+        return top
 
 
 retrieval_service = RetrievalService()


### PR DESCRIPTION
- pipeline/retrieval/retrieval_service.py: RRF → alpha_hybrid 교체, 법령/판례 독립 랭킹(각 rank 1~TOP_K), 합친 풀 min-max 정규화, TOP_K=20
- app/schemas.py: rrf→law/prec, rrf_score→hybrid_score, top_results→law_results/prec_results
- app/main.py: _retrieve_clause/_rerank_all/analyze_single_clause 법령/판례 분리 처리, RERANKING_TOP_N=20
- frontend/app/analysis/page.tsx: 응답 구조 변경(law_results/prec_results) 반영

## 📝 변경 사항
### RAG 리랭킹 개선: alpha_hybrid + 법령/판례 분리

> 브랜치: `110-feature-rag-llm생성-연결` · 커밋: `a0a87a5`

#### 개요

검색(RAG) 단계의 리랭킹을 **RRF → alpha_hybrid**로 교체하고, 법령/판례를 **혼합 → 분리** 구조로 변경했습니다. alpha_hybrid와 분리 랭킹은 평가(`evaluation/legal_retrieval_eval_multi.py`)에서 성능 검증된 방식인데, 실제 서비스 코드(`retrieval_service`, API)에는 반영돼 있지 않아 이를 일치시켰습니다.

**변경 파일 4개:**
- `pipeline/retrieval/retrieval_service.py` (검색 로직, 핵심)
- `app/schemas.py` (API 스키마)
- `app/main.py` (API 엔드포인트)
- `frontend/app/analysis/page.tsx` (프론트)

---

#### 1. 검색 로직 — `pipeline/retrieval/retrieval_service.py`

**리랭킹 알고리즘 교체:**
- 기존: RRF (`1/(k+rank)` 순위 기반 융합)
- 변경: alpha_hybrid (점수 기반 가중합)
  - 법령: `0.20·BM25 + 0.80·Dense` (Dense 위주)
  - 판례: `0.70·BM25 + 0.30·Dense` (BM25 위주)
  - alpha 값은 평가 sweep 최적값
- 정규화: 법령+판례를 **합친 풀에서 min-max 정규화** 후 도메인 분리 (평가 코드와 동일)
- 법령/판례 **각각 독립 랭킹** (각자 rank 1~20), 슬롯 경쟁 없음

**`retrieve(payload)` 반환 구조 변경:**
```python
# 기존
{"bm25": [...], "dense": [...], "rrf": [혼합 단일 리스트]}
# 변경
{"bm25": [...], "dense": [...], "law": [법령 rank 1~20], "prec": [판례 rank 1~20]}
```

**불변:** `load()`, `is_ready`, `corpus` 구조, pgvector 검색 방식 — 그대로 유지 (DB/인덱스 로직 무손상)

---

#### 2. API 스키마 — `app/schemas.py`

| 모델 | 기존 | 변경 |
|---|---|---|
| `RetrievalHit` | `rrf_score` | `hybrid_score` |
| `RankedDocument` | `rrf_score` | `hybrid_score` |
| `ClauseRetrievalResult` | `bm25, dense, rrf` | `bm25, dense, law, prec` |
| `ClauseRanking` | `top_results` | `law_results, prec_results` |
| `ClauseAnalysisResponse` | `top_results` | `law_results, prec_results` |

---

#### 3. API 엔드포인트 — `app/main.py`

- `_retrieve_clause`: `retrieve()`의 `law`/`prec` 키로 매핑
- `_rerank_all`: 법령/판례 따로 DB 조회 후 분리 반환 (`law_results`/`prec_results`)
- `analyze_single_clause`: 응답에 `law_results`/`prec_results` 반환
- `RERANKING_TOP_N`: `5 → 20` (법령 20 + 판례 20)

##### ⚠️ API 응답 변경 (소비자 필수 확인)

**`POST /api/analyze/clause`** — 요청은 그대로, **응답 구조 변경:**
```jsonc
// 기존
{ "index": 0, "clause": "...", "expansion": {...},
  "top_results": [ {"source_type": "law"|"precedent", "rrf_score": 0.8, "title": "...", "content": "..."} ] }

// 변경
{ "index": 0, "clause": "...", "expansion": {...},
  "law_results":  [ {"source_type": "law",       "hybrid_score": 0.8, "title": "...", "content": "..."} ],
  "prec_results": [ {"source_type": "precedent", "hybrid_score": 0.8, "title": "...", "content": "..."} ] }
```
- `top_results` 삭제 → `law_results` + `prec_results`
- `rrf_score` → `hybrid_score`
- `title`, `content` 필드명은 **그대로** (호환)

**`POST /api/reranking`** (`RerankingResponse`): `ClauseRanking`이 `top_results` → `law_results`/`prec_results`로 동일하게 변경됨.

영향 없는 엔드포인트: `/api/documents` 계열 3개 (구조 변경 없음)

---

#### 4. 프론트엔드 — `frontend/app/analysis/page.tsx`

`/api/analyze/clause` 응답 파싱을 새 구조에 맞춤:
```js
// 기존: data.top_results 를 source_type 으로 분기
// 변경: data.law_results → 법령, data.prec_results → 판례
```
화면 렌더 로직(`LawSection`/`PrecedentSection`)은 그대로. `title`·`content` 사용 동일.

---