### PR TITLE
Bug/118 계약서 전처리 로직 실패 및 공통 특약 분석 시 500 에러 발생

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from sqlalchemy import text
 from app.schemas import (
     AnalyzeClauseRequest,
     ClauseAnalysisResponse,
+    ClauseAnalysisV2Response,
     ClauseExpansion,
     ClauseRanking,
     ClauseRetrieval,
@@ -39,19 +40,24 @@ from app.schemas import (
     LayoutParseResponse,
     QueryExpansionResponse,
     RankedDocument,
+    ReportRequest,
+    ReportV2Request,
     RerankingResponse,
     RetrievalHit,
     RetrievalResponse,
 )
 from pipeline.preprocessing.schema import LeaseContract
+from pipeline.retrieval.query_expansion.query_expansion_schema import ClauseQueryExpansion
 from pipeline.retrieval.retrieval_service import retrieval_service
+from pipeline.generation.report_generator import generate_report_from_data, ReportOutput
+from pipeline.generation.report_generator_v2 import generate_clause_summary, generate_final_report, FinalReportOutput, COMMON_TERMS_COUNT
 from shared.db.connection import get_db_client
 from shared.storage.gcs_client import get_gcs_client
 
 log = logging.getLogger(__name__)
 
 # 특약 병렬 처리 스레드 수
-CLAUSE_WORKERS = 4
+CLAUSE_WORKERS = 50
 # reranking 단계에서 반환할 상위 문서 수
 RERANKING_TOP_N = 20
 
@@ -226,7 +232,57 @@ async def analyze_single_clause(request: AnalyzeClauseRequest) -> ClauseAnalysis
     if not retrieval_service.is_ready:
         raise HTTPException(status_code=503, detail="코퍼스 로딩 중")
 
-    # 1. 쿼리 확장
+    # 1. 쿼리 확장 (상위 COMMON_TERMS_COUNT개 특약은 건너뜀)
+    if request.clause_index < COMMON_TERMS_COUNT:
+        return ClauseAnalysisResponse(
+            index=request.clause_index,
+            clause=request.clause_text,
+            expansion=ClauseQueryExpansion(expansion_query="", keywords=[]),
+            law_results=[],
+            prec_results=[],
+        )
+    
+    expansion = await _run_in_executor(_expand_clause, request.clause_index, request.clause_text)
+
+
+@app.post("/api/analyze/report", response_model=ReportOutput)
+async def analyze_report(request: ReportRequest) -> ReportOutput:
+    """모든 특약의 분석 결과를 취합하여 최종 체크리스트와 보고서를 생성한다."""
+    if not retrieval_service.is_ready:
+        raise HTTPException(status_code=503, detail="코퍼스 로딩 중")
+
+    def _run_report_gen():
+        clauses_with_hits_dict = [c.model_dump() for c in request.clauses_with_hits]
+        return generate_report_from_data(
+            property_info=request.property_info,
+            common_terms=request.common_terms,
+            clauses_with_hits=clauses_with_hits_dict
+        )
+
+    return await _run_in_executor(_run_report_gen)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# V2 비동기/병렬 파이프라인 엔드포인트
+# ──────────────────────────────────────────────────────────────────────
+
+@app.post("/api/analyze/clause_v2", response_model=ClauseAnalysisV2Response)
+async def analyze_single_clause_v2(request: AnalyzeClauseRequest) -> ClauseAnalysisV2Response:
+    """단일 특약에 대해 [QE -> 검색 -> LLM 요약]까지 논스톱으로 실행한다."""
+    if not retrieval_service.is_ready:
+        raise HTTPException(status_code=503, detail="코퍼스 로딩 중")
+
+    # 1. 쿼리 확장 (상위 COMMON_TERMS_COUNT개 특약은 건너뜀)
+    if request.clause_index < COMMON_TERMS_COUNT:
+        return ClauseAnalysisV2Response(
+            index=request.clause_index,
+            clause=request.clause_text,
+            expansion=ClauseQueryExpansion(expansion_query="", keywords=[]),
+            law_results=[],
+            prec_results=[],
+            llm_related_laws=[],
+        )
+    
     expansion = await _run_in_executor(_expand_clause, request.clause_index, request.clause_text)
 
     # 2. 하이브리드 검색
@@ -234,14 +290,43 @@ async def analyze_single_clause(request: AnalyzeClauseRequest) -> ClauseAnalysis
 
     # 3. 리랭킹 및 문서 내용 병합
     ranking_res = await _run_in_executor(_rerank_all, [retrieval_res])
+    
+    law_results = ranking_res[0].law_results if ranking_res else []
+    prec_results = ranking_res[0].prec_results if ranking_res else []
 
-    return ClauseAnalysisResponse(
+    # 4. LLM 요약 (개별)
+    def _run_llm_summary():
+        laws_dict = [d.model_dump() for d in law_results]
+        precs_dict = [d.model_dump() for d in prec_results]
+        # lru_cache를 위해 hashable한 타입(str)으로 변환
+        laws_json = json.dumps(laws_dict, sort_keys=True)
+        precs_json = json.dumps(precs_dict, sort_keys=True)
+        return generate_clause_summary(request.clause_text, laws_json, precs_json)
+    
+    llm_related_laws = await _run_in_executor(_run_llm_summary)
+
+    return ClauseAnalysisV2Response(
         index=request.clause_index,
         clause=request.clause_text,
         expansion=expansion.expansion,
-        law_results=ranking_res[0].law_results if ranking_res else [],
-        prec_results=ranking_res[0].prec_results if ranking_res else [],
+        law_results=law_results,
+        prec_results=prec_results,
+        llm_related_laws=llm_related_laws,
     )
+
+
+@app.post("/api/analyze/report_v2", response_model=FinalReportOutput)
+async def analyze_report_v2(request: ReportV2Request) -> FinalReportOutput:
+    """모든 특약의 요약 결과를 바탕으로 최종 체크리스트와 연관성 분석을 수행한다."""
+    def _run_final_report_gen():
+        clauses_with_summaries_dict = [c.model_dump() for c in request.clauses_with_summaries]
+        return generate_final_report(
+            property_info=request.property_info,
+            common_terms=request.common_terms,
+            clauses_with_hits_and_summaries=clauses_with_summaries_dict
+        )
+
+    return await _run_in_executor(_run_final_report_gen)
 
 # ──────────────────────────────────────────────────────────────────────
 # 기존 (레거시) API 들 - 필요시 삭제 가능
@@ -314,22 +399,50 @@ async def _expand_all(contract: LeaseContract) -> list[ClauseExpansion]:
     special_terms = [t.strip() for t in contract.special_terms if t.strip()]
 
     loop = asyncio.get_event_loop()
-    tasks = [
-        loop.run_in_executor(_clause_executor, _expand_clause, i, term)
-        for i, term in enumerate(special_terms)
-    ]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
+    
+    # Pre-allocate a list for all expansions, with placeholders for skipped terms
+    all_expansions: list[ClauseExpansion | Any] = [None] * len(special_terms)
+    
+    tasks = []
+    task_indices = [] # To keep track of original indices for tasks
 
-    clauses: list[ClauseExpansion] = []
-    for i, result in enumerate(results):
+    for i, term in enumerate(special_terms):
+        if i < COMMON_TERMS_COUNT:
+            # For the first COMMON_TERMS_COUNT terms, create a placeholder
+            all_expansions[i] = ClauseExpansion(
+                index=i,
+                clause=term,
+                expansion=ClauseQueryExpansion(expansion_query="", keywords=[]),
+                retrieval_payload={},
+            )
+        else:
+            # For other terms, create a task for expansion
+            tasks.append(loop.run_in_executor(_clause_executor, _expand_clause, i, term))
+            task_indices.append(i)
+
+    # Execute tasks for non-common terms
+    expanded_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Populate all_expansions list with results from executor
+    for task_idx, result in zip(task_indices, expanded_results):
         if isinstance(result, Exception):
-            log.error("특약 %d 쿼리 확장 실패: %s", i, result)
+            log.error("특약 %d 쿼리 확장 실패: %s", task_idx, result)
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=f"특약 {i} 쿼리 확장 실패: {result}",
+                detail=f"특약 {task_idx} 쿼리 확장 실패: {result}",
             )
-        clauses.append(result)
-    return sorted(clauses, key=lambda c: c.index)
+        all_expansions[task_idx] = result
+            
+    # Ensure all elements are ClauseExpansion and handle potential None if something went wrong
+    final_clauses: list[ClauseExpansion] = []
+    for item in all_expansions:
+        if item is not None:
+            final_clauses.append(item)
+        else:
+            # This case should ideally not happen if logic is correct, but for safety
+            log.warning("Unexpected None in all_expansions list, skipping.")
+            
+    return sorted(final_clauses, key=lambda c: c.index)
 
 
 async def _retrieve_all(clauses: list[ClauseExpansion]) -> list[ClauseRetrieval]:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -54,6 +54,48 @@ class ClauseAnalysisResponse(BaseModel):
     prec_results: list[RankedDocument]  # 판례 (rank 1~TOP_K, 독립)
 
 
+class ClauseWithHits(BaseModel):
+    index: int
+    clause: str
+    laws: list[dict]
+    precs: list[dict]
+
+
+class ReportRequest(BaseModel):
+    property_info: dict
+    common_terms: list[str]
+    clauses_with_hits: list[ClauseWithHits]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# V2 파이프라인 스키마 (완전 비동기/병렬)
+# ──────────────────────────────────────────────────────────────────────
+
+class ClauseAnalysisV2Response(BaseModel):
+    index: int
+    clause: str
+    expansion: ClauseQueryExpansion
+    law_results: list[RankedDocument]   # 법령 (rank 1~TOP_K, 독립)
+    prec_results: list[RankedDocument]  # 판례 (rank 1~TOP_K, 독립)
+    llm_related_laws: list[dict]        # LLM 요약 결과
+
+class ClauseWithSummary(BaseModel):
+    index: int
+    clause: str
+    summaries: list[dict]
+
+class ReportV2Request(BaseModel):
+    property_info: dict
+    common_terms: list[str]
+    clauses_with_summaries: list[ClauseWithSummary]
+
+class ChecklistResponse(BaseModel):
+    contract_checklist: list[dict]
+
+class RelationsResponse(BaseModel):
+    related_clauses_map: dict[str, list[dict]]
+
+
 # ──────────────────────────────────────────────────────────────────────
 # 기존 (레거시)
 # ──────────────────────────────────────────────────────────────────────

--- a/frontend/app/analysis/page.tsx
+++ b/frontend/app/analysis/page.tsx
@@ -8,14 +8,49 @@ import { PrecedentSection } from "@/components/analysis/PrecedentSection";
 import { BottomActionBar } from "@/components/analysis/BottomActionBar";
 import type { LawItem } from "@/components/analysis/LawSection";
 import type { PrecedentItem } from "@/components/analysis/PrecedentSection";
-import { Loader2, AlertCircle } from "lucide-react";
+import { Loader2, AlertCircle, ChevronDown, X } from "lucide-react";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
+
+type Notification = {
+  id: string;
+  clauseIdx: number;
+  message: string;
+  isExiting?: boolean;
+  timeoutId?: NodeJS.Timeout; // Add this line
+};
 
 type ClauseResult = {
   laws: LawItem[];
   precedents: PrecedentItem[];
+  rawLaws: any[];
+  rawPrecs: any[];
+  llmRelatedLaws: RelatedLaw[];
   status: "loading" | "done" | "error";
+};
+
+type ChecklistItem = {
+  item: string;
+  description: string;
+  basis: string[];
+};
+
+type RelatedLaw = {
+  type: string;
+  ref: string;
+  summary: string;
+  content: string;
+};
+
+type RelatedClause = {
+  clause_id: string;
+  clause_text: string;
+  relation: string;
+};
+
+type FinalReportOutput = {
+  contract_checklist: ChecklistItem[];
+  related_clauses_map: Record<string, RelatedClause[]>;
 };
 
 /* ─── Page ─────────────────────────────────────────────────────────── */
@@ -27,6 +62,26 @@ export default function AnalysisPage() {
   const [clauseResults, setClauseResults] = useState<Record<number, ClauseResult>>({});
   const [analysisStatus, setAnalysisStatus] = useState<"loading" | "done">("loading");
   const [completedCount, setCompletedCount] = useState(0);
+  
+  const [reportData, setReportData] = useState<FinalReportOutput | null>(null);
+  const [reportStatus, setReportStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  // 알림 관리 (최대 5개, 초과 시 순차 제거)
+  useEffect(() => {
+    // If the number of notifications exceeds 5 (i.e., 6 or more)
+    if (notifications.length > 5) {
+      const oldestNotification = notifications[0]; // Always target the very oldest
+      
+      // Clear its auto-dismissal timeout if it exists
+      if (oldestNotification.timeoutId) {
+        clearTimeout(oldestNotification.timeoutId);
+      }
+
+      // Remove the oldest notification immediately (without isExiting animation for the limit)
+      setNotifications(current => current.slice(1)); // Remove the first element
+    }
+  }, [notifications]);
 
   useEffect(() => {
     const storedFileName = sessionStorage.getItem("ade.analysis.fileName");
@@ -61,7 +116,7 @@ export default function AnalysisPage() {
 
         const initialResults: Record<number, ClauseResult> = {};
         terms.forEach((_: string, i: number) => {
-          initialResults[i] = { laws: [], precedents: [], status: "loading" };
+          initialResults[i] = { laws: [], precedents: [], rawLaws: [], rawPrecs: [], llmRelatedLaws: [], status: "loading" };
         });
         setClauseResults(initialResults);
 
@@ -70,10 +125,10 @@ export default function AnalysisPage() {
           return;
         }
 
-        // 3. 병렬 분석 실행
+        // 3. 병렬 분석 실행 (V2: RAG + LLM 요약)
         terms.forEach(async (termText: string, index: number) => {
           try {
-            const res = await fetch(`${API_BASE}/api/analyze/clause`, {
+            const res = await fetch(`${API_BASE}/api/analyze/clause_v2`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
@@ -89,27 +144,50 @@ export default function AnalysisPage() {
               const termLaws: LawItem[] = [];
               const termPrecedents: PrecedentItem[] = [];
 
-              (data.law_results ?? []).forEach((doc: any) => {
-                termLaws.push({
-                  rank: termLaws.length + 1,
-                  name: doc.title,
-                  detail: doc.content
+              if (data && Array.isArray(data.law_results)) {
+                data.law_results.forEach((doc: any) => {
+                  termLaws.push({
+                    rank: doc.rank ?? termLaws.length + 1,
+                    name: doc.title ?? "제목 없음",
+                    detail: doc.content ?? "내용 없음"
+                  });
                 });
-              });
+              }
 
-              (data.prec_results ?? []).forEach((doc: any) => {
-                termPrecedents.push({
-                  title: doc.title,
-                  tags: ["#관련판례"],
-                  facts: [{ label: "판결 요지", text: doc.content }],
-                  guide: []
+              if (data && Array.isArray(data.prec_results)) {
+                data.prec_results.forEach((doc: any) => {
+                  termPrecedents.push({
+                    title: doc.title ?? "제목 없음",
+                    tags: ["#관련판례"],
+                    facts: [{ label: "판결 요지", text: doc.content ?? "내용 없음" }],
+                    guide: []
+                  });
                 });
-              });
+              }
 
               setClauseResults(prev => ({
                 ...prev,
-                [index]: { laws: termLaws, precedents: termPrecedents, status: "done" }
+                [index]: { 
+                  laws: termLaws, 
+                  precedents: termPrecedents, 
+                  rawLaws: data?.law_results ?? [], 
+                  rawPrecs: data?.prec_results ?? [],
+                  llmRelatedLaws: data?.llm_related_laws ?? [],
+                  status: "done" 
+                }
               }));
+
+              setNotifications(prev => {
+                const newNotification = {
+                  id: Date.now().toString() + "-" + index, // Ensure unique ID
+                  clauseIdx: index,
+                  message: `특약 ${index + 1} 분석이 완료되었습니다.`,
+                };
+                const timeoutId = setTimeout(() => {
+                  setNotifications(current => current.filter(n => n.id !== newNotification.id));
+                }, 10000); // 10초 후 제거
+                return [...prev, { ...newNotification, timeoutId }];
+              });
             } else {
               setClauseResults(prev => ({ ...prev, [index]: { ...prev[index], status: "error" } }));
             }
@@ -134,6 +212,56 @@ export default function AnalysisPage() {
     }
   }, []);
 
+  // 4. 모든 특약 분석 완료 후 종합 리포트 생성 (Phase 2 - V2)
+  useEffect(() => {
+    if (specialTerms.length > 0 && completedCount === specialTerms.length && reportStatus === "idle") {
+      setReportStatus("loading");
+      
+      const storedContract = sessionStorage.getItem("ade.analysis.contract");
+      if (!storedContract) {
+        setReportStatus("error");
+        return;
+      }
+
+      try {
+        const contract = JSON.parse(storedContract);
+        const clausesWithSummaries = specialTerms.map((term, index) => {
+          const res = clauseResults[index];
+          return {
+            index: index + 6, // 서버의 COMMON_TERMS_COUNT(6) 이후부터 인덱스 시작
+            clause: term,
+            summaries: res?.llmRelatedLaws || []
+          };
+        });
+
+        fetch(`${API_BASE}/api/analyze/report_v2`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            property_info: contract.property_info || {},
+            common_terms: contract.special_terms?.slice(0, 6) || [],
+            clauses_with_summaries: clausesWithSummaries
+          }),
+        })
+        .then(res => {
+          if (!res.ok) throw new Error("Report API failed");
+          return res.json();
+        })
+        .then(data => {
+          setReportData(data);
+          setReportStatus("done");
+        })
+        .catch(err => {
+          console.error("종합 리포트 생성 에러:", err);
+          setReportStatus("error");
+        });
+      } catch (e) {
+        console.error("리포트 생성 중 파싱 오류", e);
+        setReportStatus("error");
+      }
+    }
+  }, [completedCount, specialTerms.length, clauseResults, reportStatus]);
+
   const handleTermClick = (index: number) => {
     const element = document.getElementById(`analysis-result-${index}`);
     if (element) {
@@ -150,6 +278,35 @@ export default function AnalysisPage() {
         activeTab="analysis"
       />
 
+      {/* Toast Notifications */}
+      <div className="fixed top-24 right-8 z-50 flex flex-col gap-3 pointer-events-none">
+        {notifications.map(n => (
+          <div 
+            key={n.id} 
+            className={`flex items-center justify-between gap-4 p-4 bg-white border border-green-200 rounded-xl shadow-xl w-80 pointer-events-auto transition-all duration-500
+              ${n.isExiting ? 'opacity-0 translate-x-full' : 'opacity-100 translate-x-0'}`
+            }
+          >
+            <div 
+              className="flex-1 cursor-pointer text-sm font-semibold text-gray-800 hover:text-blue-600 transition-colors"
+              onClick={() => {
+                handleTermClick(n.clauseIdx);
+                if (n.timeoutId) clearTimeout(n.timeoutId);
+                setNotifications(prev => prev.filter(x => x.id !== n.id));
+              }}
+            >
+              ✅ {n.message}
+            </div>
+            <button onClick={() => {
+                if (n.timeoutId) clearTimeout(n.timeoutId);
+                setNotifications(prev => prev.filter(x => x.id !== n.id));
+              }} className="text-gray-400 hover:text-gray-600 bg-gray-50 hover:bg-gray-100 rounded-full p-1 transition-colors">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+
       <div className="flex flex-row flex-1 min-h-0">
         <DocumentPanel 
           specialTerms={specialTerms}
@@ -161,53 +318,298 @@ export default function AnalysisPage() {
           className="flex flex-col flex-1 overflow-y-auto px-8 py-8 gap-8"
           style={{ background: "#FAF9FD", paddingBottom: "128px" }}
         >
-          {specialTerms.length > 0 ? (
-            specialTerms.map((term, idx) => (
-              <div 
-                key={idx} 
-                id={`analysis-result-${idx}`}
-                className="flex flex-col gap-6 p-6 rounded-xl border bg-white shadow-sm scroll-mt-4"
-                style={{ borderColor: "#E2E8F0" }}
-              >
-                {/* 특약 헤더 */}
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex flex-col gap-1">
-                    <span className="text-xs font-bold text-blue-600 uppercase tracking-wider">특약 {idx + 1} 분석 결과</span>
-                    <h4 className="text-base font-semibold text-gray-900 leading-relaxed">
-                      "{term}"
-                    </h4>
-                  </div>
-                  {clauseResults[idx]?.status === "loading" && (
-                    <div className="flex items-center gap-2 text-sm text-blue-500 font-medium bg-blue-50 px-3 py-1.5 rounded-full">
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                      분석 중
-                    </div>
-                  )}
-                  {clauseResults[idx]?.status === "error" && (
-                    <div className="flex items-center gap-2 text-sm text-red-500 font-medium bg-red-50 px-3 py-1.5 rounded-full">
-                      <AlertCircle className="h-4 w-4" />
-                      분석 실패
-                    </div>
-                  )}
-                </div>
-
-                {/* 분석 결과 (로딩 완료 시에만) */}
-                {clauseResults[idx]?.status !== "loading" && (
-                  <div className="flex flex-col gap-8 pt-4 border-t border-gray-100">
-                    {clauseResults[idx].laws.length > 0 ? (
-                      <LawSection laws={clauseResults[idx].laws} />
-                    ) : (
-                      <p className="text-sm text-gray-400 italic">관련 법령을 찾지 못했습니다.</p>
-                    )}
-                    
-                    {clauseResults[idx].precedents.length > 0 && (
-                      <PrecedentSection precedents={clauseResults[idx].precedents} />
-                    )}
-                  </div>
-                )}
+          {/* 종합 체크리스트 렌더링 */}
+          {reportStatus === "loading" && (
+            <div className="flex flex-col gap-4 p-6 rounded-xl border bg-blue-50/50 shadow-sm border-blue-100">
+              <div className="flex items-center gap-3">
+                <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+                <h3 className="text-lg font-bold text-gray-900">종합 분석 보고서 생성 중...</h3>
               </div>
-            ))
-          ) : (
+              <p className="text-sm text-gray-500 ml-8">모든 특약의 검색 결과를 바탕으로 계약 전 필수 확인 체크리스트를 만들고 있습니다. 잠시만 기다려주세요.</p>
+            </div>
+          )}
+
+          {reportStatus === "error" && (
+            <div className="flex flex-col gap-4 p-6 rounded-xl border bg-red-50/50 shadow-sm border-red-100">
+              <div className="flex items-center gap-3">
+                <AlertCircle className="h-5 w-5 text-red-500" />
+                <h3 className="text-lg font-bold text-gray-900">종합 분석 보고서 생성 실패</h3>
+              </div>
+              <p className="text-sm text-red-400 ml-8">보고서 생성 중 오류가 발생했습니다.</p>
+            </div>
+          )}
+
+          {reportStatus === "done" && reportData && reportData.contract_checklist.length > 0 && (
+            <details className="group flex flex-col p-6 rounded-xl border bg-white shadow-sm border-blue-200" open>
+              <summary className="flex items-center gap-2 mb-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden select-none outline-none">
+                <div className="w-1.5 h-6 bg-blue-600 rounded-full" />
+                <h3 className="text-xl font-bold text-gray-900 tracking-tight">계약 전 필수 확인 체크리스트</h3>
+                <ChevronDown className="w-5 h-5 text-gray-400 transition-transform group-open:rotate-180 ml-auto" />
+              </summary>
+              <div className="flex flex-col gap-4 mt-4">
+                {reportData.contract_checklist.map((item, idx) => (
+                  <details key={idx} className="group bg-gray-50 border border-gray-100 rounded-lg">
+                    <summary className="flex items-center gap-2 p-4 cursor-pointer list-none [&::-webkit-details-marker]:hidden select-none outline-none">
+                      <span className="flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-sm font-bold flex-shrink-0">{idx + 1}</span>
+                      <h4 className="text-base font-semibold text-gray-900">{item.item}</h4>
+                      <ChevronDown className="w-4 h-4 text-gray-400 transition-transform group-open:rotate-180 ml-auto flex-shrink-0" />
+                    </summary>
+                    <div className="p-4 pt-0">
+                      <p className="text-sm text-gray-700 leading-relaxed ml-8">{item.description}</p>
+                      {item.basis && item.basis.length > 0 && (() => {
+                      const laws: string[] = [];
+                      const precs: string[] = [];
+                      const clauses: string[] = [];
+                      
+                      item.basis.forEach(b => {
+                        if (b.includes("특약")) {
+                          clauses.push(b);
+                        } else if (/[법령조항칙]/.test(b) && !/^\d+[가-힣]+/.test(b)) {
+                          laws.push(b.replace(/_/g, ' '));
+                        } else {
+                          const parts = b.split(",").map(p => p.trim());
+                          if (parts.length > 1) {
+                            const prefixMatch = parts[0].match(/^(\d+[가-힣]+)/);
+                            if (prefixMatch) {
+                              const prefix = prefixMatch[1];
+                              parts.forEach((p, idx) => {
+                                if (idx === 0) precs.push(p);
+                                else if (/^\d+$/.test(p)) precs.push(prefix + p);
+                                else precs.push(p);
+                              });
+                            } else {
+                              precs.push(...parts);
+                            }
+                          } else {
+                            precs.push(b);
+                          }
+                        }
+                      });
+
+                      return (
+                        <div className="ml-8 mt-3 flex flex-col gap-3">
+                          {clauses.length > 0 && (
+                            <div className="flex flex-wrap gap-2">
+                              {clauses.map((c, cIdx) => (
+                                <span key={`c-${cIdx}`} className="text-xs bg-gray-200 text-gray-700 px-2 py-1 rounded-md font-medium">{c}</span>
+                              ))}
+                            </div>
+                          )}
+                          
+                          {laws.length > 0 && (
+                            <details className="group border border-gray-200 rounded-lg overflow-hidden">
+                              <summary className="text-sm font-semibold text-gray-700 bg-gray-50 px-4 py-2 cursor-pointer hover:bg-gray-100 select-none">
+                                근거 법령
+                              </summary>
+                              <div className="flex flex-col gap-2 p-4 bg-white border-t border-gray-100">
+                                {laws.map((law, lIdx) => (
+                                  <div key={`l-${lIdx}`} className="text-sm text-gray-600 flex items-start gap-2">
+                                    <span className="w-1.5 h-1.5 rounded-full bg-blue-400 mt-1.5 flex-shrink-0" />
+                                    <span>{law}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            </details>
+                          )}
+
+                          {precs.length > 0 && (
+                            <details className="group border border-gray-200 rounded-lg overflow-hidden">
+                              <summary className="text-sm font-semibold text-gray-700 bg-gray-50 px-4 py-2 cursor-pointer hover:bg-gray-100 select-none">
+                                근거 판례
+                              </summary>
+                              <div className="flex flex-col gap-2 p-4 bg-white border-t border-gray-100">
+                                {precs.map((prec, pIdx) => (
+                                  <div key={`p-${pIdx}`} className="text-sm text-gray-600 flex items-start gap-2">
+                                    <span className="w-1.5 h-1.5 rounded-full bg-green-400 mt-1.5 flex-shrink-0" />
+                                    <span>{prec}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            </details>
+                          )}
+                        </div>
+                      );
+                    })()}
+                    </div>
+                  </details>
+                ))}
+              </div>
+            </details>
+          )}
+
+          {/* 개별 특약 렌더링 */}
+          {specialTerms.length > 0 && (
+            <details className="group flex flex-col mt-4" open>
+              <summary className="flex items-center gap-2 mb-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden select-none outline-none">
+                <div className="w-1.5 h-6 bg-blue-600 rounded-full" />
+                <h3 className="text-xl font-bold text-gray-900 tracking-tight">특약 분석 결과</h3>
+                <ChevronDown className="w-5 h-5 text-gray-400 transition-transform group-open:rotate-180 ml-auto" />
+              </summary>
+              <div className="flex flex-col gap-8 mt-4">
+                {specialTerms.map((term, idx) => {
+                  // 법령과 판례 분리 로직 (V2: 개별 특약의 상태에서 가져옴)
+                  const llmRelatedLaws = clauseResults[idx]?.llmRelatedLaws || [];
+                  const llmLaws = llmRelatedLaws.filter((l: any) => l.type === "법령" || (!l.type && /[법령조항칙]/.test(l.ref))) || [];
+                  const llmPrecs = llmRelatedLaws.filter((l: any) => l.type === "판례" || (!l.type && !/[법령조항칙]/.test(l.ref))) || [];
+                  
+                  // 연관성 분석 로직 (V2: 통합 리포트 데이터에서 가져옴)
+                  const llmRelatedClauses = reportData?.related_clauses_map?.[`특약${idx + 1}`] || [];
+
+                  // 판례 제목 포맷팅 함수 (콤마 분리 및 대괄호 처리)
+                  const formatPrecTitle = (ref: string) => {
+                    const parts = ref.split(",").map(p => p.trim());
+                    if (parts.length > 1) {
+                      const prefixMatch = parts[0].match(/^(\d+[가-힣]+)/);
+                      if (prefixMatch) {
+                        const prefix = prefixMatch[1];
+                        return parts.map((p, pIdx) => {
+                          if (pIdx === 0) return `[${p}]`;
+                          if (/^\d+$/.test(p)) return `[${prefix}${p}]`;
+                          return `[${p}]`;
+                        }).join(", ");
+                      }
+                    }
+                    return `[${ref}]`;
+                  };
+
+                  return (
+                    <div 
+                      key={idx} 
+                      id={`analysis-result-${idx}`}
+                      className="rounded-xl border bg-white shadow-sm scroll-mt-4"
+                      style={{ borderColor: "#E2E8F0" }}
+                    >
+                      <details className="group">
+                        <summary className="flex items-start justify-between gap-4 p-6 border-b border-gray-100 cursor-pointer list-none [&::-webkit-details-marker]:hidden select-none outline-none hover:bg-gray-50 transition-colors rounded-t-xl group-open:rounded-b-none rounded-b-xl">
+                          <div className="flex items-center gap-3">
+                            <span className="flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-sm font-bold flex-shrink-0">{idx + 1}</span>
+                            <h4 className="text-base font-semibold text-gray-900 leading-relaxed">
+                              {term}
+                            </h4>
+                          </div>
+                          <div className="flex items-center gap-3 ml-auto">
+                            {clauseResults[idx]?.status === "loading" && (
+                              <div className="flex items-center gap-2 text-sm text-blue-500 font-medium bg-blue-50 px-3 py-1.5 rounded-full flex-shrink-0">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                분석 중
+                              </div>
+                            )}
+                            {clauseResults[idx]?.status === "error" && (
+                              <div className="flex items-center gap-2 text-sm text-red-500 font-medium bg-red-50 px-3 py-1.5 rounded-full flex-shrink-0">
+                                <AlertCircle className="h-4 w-4" />
+                                분석 실패
+                              </div>
+                            )}
+                            <ChevronDown className="w-5 h-5 text-gray-400 transition-transform group-open:rotate-180 flex-shrink-0" />
+                          </div>
+                        </summary>
+
+                        <div className="p-6 pt-4 flex flex-col gap-6">
+
+                  {/* LLM 요약 (Phase 1 완료 시 즉시 노출) */}
+                  {clauseResults[idx]?.status === "done" && (
+                    <div className="flex flex-col gap-3">
+                      {llmLaws.length > 0 && (
+                        <details className="group border border-blue-200 rounded-lg overflow-hidden">
+                          <summary className="text-sm font-semibold text-blue-900 bg-blue-50 px-4 py-3 cursor-pointer hover:bg-blue-100 select-none">
+                            관련 법령
+                          </summary>
+                          <div className="flex flex-col gap-4 p-4 bg-white border-t border-blue-100">
+                            {llmLaws.map((law, lIdx) => (
+                              law.summary && (
+                                <div key={`law-sum-${lIdx}`} className="text-sm text-gray-700 leading-relaxed">
+                                  <strong className="block text-gray-900 mb-2">[{law.ref.replace(/_/g, ' ')}]</strong>
+                                  {law.content && (
+                                    <details className="mt-3 p-3 bg-gray-50 border border-gray-100 rounded-lg">
+                                      <summary className="text-xs font-semibold text-gray-700 cursor-pointer select-none">
+                                        원문 보기
+                                      </summary>
+                                      <p className="mt-2 text-xs whitespace-pre-wrap text-gray-600">
+                                        {law.content}
+                                      </p>
+                                    </details>
+                                  )}
+                                  <p className="whitespace-pre-wrap">{law.summary}</p>
+                                </div>
+                              )
+                            ))}
+                          </div>
+                        </details>
+                      )}
+
+                      {llmPrecs.length > 0 && (
+                        <details className="group border border-green-200 rounded-lg overflow-hidden">
+                          <summary className="text-sm font-semibold text-green-900 bg-green-50 px-4 py-3 cursor-pointer hover:bg-green-100 select-none">
+                            관련 판례
+                          </summary>
+                          <div className="flex flex-col gap-4 p-4 bg-white border-t border-green-100">
+                            {llmPrecs.map((prec, pIdx) => (
+                              prec.summary && (
+                                <div key={`prec-sum-${pIdx}`} className="text-sm text-gray-700 leading-relaxed">
+                                  <strong className="block text-gray-900 mb-2">{formatPrecTitle(prec.ref)}</strong>
+                                  {prec.content && (
+                                    <details className="mt-3 p-3 bg-gray-50 border border-gray-100 rounded-lg">
+                                      <summary className="text-xs font-semibold text-gray-700 cursor-pointer select-none">
+                                        판결 요지 보기
+                                      </summary>
+                                      <p className="mt-2 text-xs whitespace-pre-wrap text-gray-600">
+                                        {prec.content}
+                                      </p>
+                                    </details>
+                                  )}
+                                  <p className="whitespace-pre-wrap">{prec.summary}</p>
+                                </div>
+                              )
+                            ))}
+                          </div>
+                        </details>
+                      )}
+
+                      {/* 연관성 주의 (Phase 2 완료 후 노출) */}
+                      {reportStatus === "done" && llmRelatedClauses.length > 0 && (
+                        <details className="group border border-orange-200 rounded-lg overflow-hidden">
+                          <summary className="text-sm font-semibold text-orange-900 bg-orange-50 px-4 py-3 cursor-pointer hover:bg-orange-100 select-none">
+                            다른 특약과의 연관성 주의
+                          </summary>
+                          <div className="flex flex-col gap-4 p-4 bg-white border-t border-orange-100">
+                            <ul className="list-disc pl-5 space-y-4 text-sm text-gray-700 leading-relaxed">
+                              {llmRelatedClauses.map((rel, rIdx) => (
+                                <li key={`rel-${rIdx}`}>
+                                  <strong className="block text-gray-900 mb-2">[{rel.clause_id}] "{rel.clause_text}"</strong>
+                                  <p className="whitespace-pre-wrap">{rel.relation}</p>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        </details>
+                      )}
+                    </div>
+                  )}
+
+                  {/* 분석 결과 (로딩 완료 시에만) */}
+                  {clauseResults[idx]?.status !== "loading" && (
+                    <div className="flex flex-col gap-8 pt-4 border-t border-gray-100">
+                      {clauseResults[idx].laws.length > 0 ? (
+                        <LawSection laws={clauseResults[idx].laws} />
+                      ) : (
+                        <p className="text-sm text-gray-400 italic">관련 법령을 찾지 못했습니다.</p>
+                      )}
+                      
+                      {clauseResults[idx].precedents.length > 0 && (
+                        <PrecedentSection precedents={clauseResults[idx].precedents} />
+                      )}
+                    </div>
+                  )}
+                        </div>
+                      </details>
+                    </div>
+                  );
+                })}
+              </div>
+            </details>
+          )}
+
+          {!specialTerms.length && (
             <div className="flex items-center justify-center h-64 text-gray-500 border border-dashed rounded-xl">
               분석할 특약사항이 없습니다.
             </div>

--- a/frontend/components/TopNavBar.tsx
+++ b/frontend/components/TopNavBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Bell, Settings, User } from "lucide-react";
+import { useRouter } from "next/navigation";
 
 export type NavTab = "analysis" | "chatbot";
 
@@ -19,6 +20,8 @@ export function TopNavBar({
   activeTab = "analysis",
   onTabChange,
 }: TopNavBarProps) {
+  const router = useRouter();
+
   const chipText =
     mode === "upload"
       ? (fileName?.trim() || "계약서를 업로드 해주세요")
@@ -42,7 +45,10 @@ export function TopNavBar({
       >
         {/* Left: Logo + chip + status */}
         <div className="flex min-w-0 flex-wrap items-center gap-2 justify-self-start sm:gap-3">
-          <div className="flex items-center gap-2">
+          <div 
+            className="flex items-center gap-2 cursor-pointer"
+            onClick={() => router.push('/')}
+          >
             <svg width="16" height="20" viewBox="0 0 16 20" fill="none">
               <rect width="16" height="20" rx="2" fill="white" />
               <rect x="3" y="5" width="10" height="1.5" rx="0.75" fill="#1E293B" />

--- a/pipeline/generation/report_generator.py
+++ b/pipeline/generation/report_generator.py
@@ -551,17 +551,11 @@ JSON 외 텍스트, 마크다운 코드블록은 포함하지 마세요.
     return None
 
 
-def run_from_rag_result(rag_path: str, output_path: str | None = None) -> None:
+def generate_report_from_data(property_info: dict, common_terms: list, clauses_with_hits: list) -> ReportOutput:
     """
-    test_rag_one_contract.py 결과 JSON 하나를 입력받아 보고서 생성.
-
-    사용법:
-        python pipeline/generation/report_generator.py --rag-result path/to/test_rag_104.json
-        python pipeline/generation/report_generator.py --rag-result path/to/test_rag_104.json --output path/to/report.json
+    RAG 결과 데이터를 직접 입력받아 LLM 보고서를 생성하고 반환합니다.
+    API 등에서 파일 I/O 없이 직접 호출할 때 사용합니다.
     """
-    print(f"[rag-result 모드] 입력: {rag_path}")
-    property_info, common_terms, clauses_with_hits = load_from_rag_result(rag_path)
-
     # 다른 특약 원문 리스트 (관계 분석용)
     all_target_terms = [c["clause"] for c in clauses_with_hits]
 
@@ -682,11 +676,25 @@ def run_from_rag_result(rag_path: str, output_path: str | None = None) -> None:
     contract_checklist = checklist_result.get("contract_checklist", []) if checklist_result else []
     print("  [전체 체크리스트] 완료")
 
-    # ── 저장 ──────────────────────────────────────────────────────
-    final_output = ReportOutput(
+    return ReportOutput(
         contract_checklist=contract_checklist,
         clause_results=clause_results,
     )
+
+
+def run_from_rag_result(rag_path: str, output_path: str | None = None) -> None:
+    """
+    test_rag_one_contract.py 결과 JSON 하나를 입력받아 보고서 생성.
+
+    사용법:
+        python pipeline/generation/report_generator.py --rag-result path/to/test_rag_104.json
+        python pipeline/generation/report_generator.py --rag-result path/to/test_rag_104.json --output path/to/report.json
+    """
+    print(f"[rag-result 모드] 입력: {rag_path}")
+    property_info, common_terms, clauses_with_hits = load_from_rag_result(rag_path)
+
+    final_output = generate_report_from_data(property_info, common_terms, clauses_with_hits)
+
     if not output_path:
         stem = Path(rag_path).stem  # e.g. "test_rag_104"
         output_path = str(Path(rag_path).parent / f"{stem}_report.json")

--- a/pipeline/generation/report_generator_v2.py
+++ b/pipeline/generation/report_generator_v2.py
@@ -1,0 +1,380 @@
+import json
+import os
+import re
+from enum import Enum
+from pathlib import Path
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, field_validator
+import vertexai
+from vertexai.generative_models import GenerativeModel, GenerationConfig
+
+load_dotenv()
+
+PROJECT_ID = os.getenv("GCP_PROJECT_ID")
+LOCATION = os.getenv("GCP_LOCATION")
+vertexai.init(project=PROJECT_ID, location=LOCATION)
+
+MODEL_NAME_FLASH = "gemini-2.5-flash"
+MODEL_NAME_FLASH_LITE = "gemini-2.5-flash-lite"
+COMMON_TERMS_COUNT = 6
+
+# ── Pydantic 스키마 ──────────────────────────────────────────────
+
+class LawType(str, Enum):
+    law  = "법령"
+    case = "판례"
+
+class SelectedLaw(BaseModel):
+    ref: str | None = None
+    summary: str | None = None
+
+class ClauseSummaryOutput(BaseModel):
+    selected_laws: list[SelectedLaw] = []
+
+    @field_validator("selected_laws", mode="before")
+    @classmethod
+    def coerce_list(cls, v):
+        if v is None:
+            return []
+        return v
+
+class RelatedClause(BaseModel):
+    clause_id: str | None = None
+    clause_text: str | None = None
+    relation: str | None = None
+
+class ChecklistItem(BaseModel):
+    item: str | None = None
+    description: str | None = None
+    basis: list[str] = []
+
+    @field_validator("basis", mode="before")
+    @classmethod
+    def coerce_basis(cls, v):
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [x.strip() for x in v.split(",") if x.strip()]
+        return v
+
+class FinalReportOutput(BaseModel):
+    contract_checklist: list[ChecklistItem] = []
+    related_clauses_map: dict[str, list[RelatedClause]] = {} # clause_id -> list of relations
+
+class LLMRelatedClauseResult(BaseModel):
+    clause_id: str
+    related_clauses: list[RelatedClause] = []
+
+    @field_validator("related_clauses", mode="after")
+    @classmethod
+    def split_combined_clause_ids(cls, v):
+        result = []
+        for item in v:
+            c_id = item.clause_id or ""
+            ids = [x.strip() for x in c_id.split(",") if x.strip()]
+            if len(ids) > 1:
+                for cid in ids:
+                    result.append(RelatedClause(
+                        clause_id=cid,
+                        clause_text=None,
+                        relation=item.relation,
+                    ))
+            else:
+                result.append(item)
+        return result
+
+class FinalReportLLMOutput(BaseModel):
+    contract_checklist: list[ChecklistItem] = []
+    clause_relations: list[LLMRelatedClauseResult] = []
+
+# ── 프롬프트 ──────────────────────────────────────────
+
+SYSTEM_PROMPT = """[역할 및 지시]
+당신은 주택임대차 계약 검토를 도와줄 법률 전문가입니다.
+아래 정보를 바탕으로 임차인이 계약 전 스스로 확인해야 할 사항을 도출하세요.
+
+- 특약 문구의 해석 가능성, 법령과의 관계, 분쟁으로 이어질 수 있는 사실관계를 객관적으로 서술하세요.
+- 명백히 법령에 위반되는 경우에는 해당 법령 조문을 근거로 위반 사실을 서술합니다.
+- "위험", "유리", "불리" 등의 평가적 표현은 절대 사용하지 마세요."""
+
+def format_laws(matches: list) -> str:
+    lines = []
+    for m in matches:
+        text = m.get("content") or m.get("doc_text") or m.get("summary") or ""
+        if not text:
+            continue
+        doc_id = m.get("doc_id", "")
+        lines.append(f"[{doc_id}]\n{text}")
+    return "\n\n".join(lines) if lines else "해당 없음"
+
+def format_precs(matches: list) -> str:
+    lines = []
+    for m in matches:
+        text = m.get("content") or m.get("summary") or ""
+        if not text or text == "nan":
+            continue
+        doc_id = m.get("doc_id", "")
+        lines.append(f"[{doc_id}]\n{text}")
+    return "\n\n".join(lines) if lines else "해당 없음"
+
+def format_property_info(property_info: dict) -> str:
+    return json.dumps(property_info, ensure_ascii=False, indent=2)
+
+def build_clause_summary_prompt(
+    target_clause: str,
+    laws: list,
+    precs: list,
+) -> str:
+    all_doc_ids = [m.get("doc_id", "") for m in laws + precs if m.get("doc_id")]
+    output_format = json.dumps(
+        {
+            "selected_laws": [{"ref": "<위 목록의 doc_id 그대로>", "summary": "<일반인이 이해할 수 있는 설명>"}]
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    return f"""
+[분석 대상 특약]
+{target_clause}
+
+[관련 법령]
+{format_laws(laws)}
+
+[관련 판례]
+{format_precs(precs)}
+
+[출력 지시]
+위 분석 대상 특약을 검토하여 아래 JSON 형식으로만 응답하세요.
+
+- selected_laws: [관련 법령]과 [관련 판례] 중 반드시 이 특약과 **직접적으로 관련 있는 상위 3개 이내의 항목**만 골라 연관도 높은 순서로 작성하세요.
+  *   **주의**: 제공된 리스트에 없는 법령 번호나 판례를 외부 지식으로 생성하여 포함하지 마세요. 반드시 대괄호 안의 식별자({', '.join(all_doc_ids)})만 사용해야 합니다.
+  *   **주의**: 연관성이 낮거나 단순히 용어가 겹치는 정도의 항목은 과감하게 제외하세요. 정말로 관련 있는 항목이 없으면 빈 배열([])을 반환하세요.
+  summary는 법률 전문 지식이 없는 일반인도 이해할 수 있도록 작성하세요.
+    · 이 법령/판례가 무슨 내용인지 쉬운 말로 설명하고,
+    · 이 특약 내용을 반복하지 않고, 이 법령/판례가 특약에 미치는 영향이나 특약과의 구체적인 연관성을 서술하세요.
+    · 전문 용어는 괄호 안에 풀어쓰세요. 예) "대항력(집을 팔아도 계속 살 수 있는 권리)"
+  summary 외에 다른 필드는 생성하지 마세요.
+- JSON 외 텍스트, 마크다운 코드블록은 포함하지 마세요.
+
+{output_format}
+"""
+
+def build_final_report_prompt(
+    property_info: dict,
+    common_terms: list,
+    target_terms_with_summaries: list[dict],
+) -> str:
+    common_text = "\n".join([f"공통특약 {i+1}: {t}" for i, t in enumerate(common_terms)])
+    
+    target_text_parts = []
+    for item in target_terms_with_summaries:
+        idx = item['index'] - COMMON_TERMS_COUNT
+        clause_id = f"특약{idx}"
+        target_text_parts.append(f"[{clause_id}]\n원문: {item['clause']}")
+        if item.get('summaries'):
+            target_text_parts.append("법적 해석 요약:")
+            for s in item['summaries']:
+                target_text_parts.append(f"- {s['ref']}: {s['summary']}")
+        target_text_parts.append("")
+    
+    target_text = "\n".join(target_text_parts)
+
+    output_format = json.dumps(
+        {
+            "contract_checklist": [
+                {"item": None, "description": None, "basis": None}
+            ],
+            "clause_relations": [
+                {
+                    "clause_id": "<특약1 등>",
+                    "related_clauses": [
+                        {"clause_id": "<특약2 또는 공통특약 1>", "clause_text": None, "relation": "<관계 설명>"}
+                    ]
+                }
+            ]
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    return f"""
+[계약서 정보]
+{format_property_info(property_info)}
+
+[공통 특약]
+{common_text}
+
+[타겟 특약 전체 및 법적 해석]
+{target_text}
+
+[출력 지시]
+위 계약서 전체와 개별 특약의 법적 해석을 바탕으로 다음 두 가지를 도출하여 JSON 형식으로만 응답하세요.
+
+1. contract_checklist: 임차인이 계약 전 확인해야 할 통합 체크리스트
+- 입력된 모든 특약을 종합 검토한 후, 확인 항목을 통합하여 작성하세요.
+- 계약서 전체 맥락에서 중요한 확인 사항을 도출하세요.
+- basis: 이 체크리스트 항목의 근거가 되는 특약 ID(예: "특약1", "공통특약 1")와 법령/판례 ref를 배열로 나열하세요. 위 내용에 등장한 식별자만 사용해야 합니다.
+
+2. clause_relations: 특약 간의 연관성 분석
+- [타겟 특약 전체]와 [공통 특약] 중 서로 동시에 적용될 때 확인이 필요하거나 충돌할 가능성이 있는 특약들의 관계를 분석하세요.
+- clause_id들은 반드시 "특약1", "공통특약 1" 형태의 ID를 사용하세요.
+- relation은 두 조항이 어떻게 연관되어 있으며 왜 주의해야 하는지 일반인 눈높이에서 설명하세요.
+- 연관성이 있는 특약에 대해서만 배열에 추가하세요.
+- clause_text는 null로 두세요.
+
+[출력 형식 예시]
+아래는 특약 4개가 하나의 계약서에 함께 존재하는 경우의 출력 예시입니다.
+실제 입력의 특약 수와 내용에 맞게 작성하세요.
+판단 표현(유리/불리/위험)은 사용하지 마세요.
+
+---
+[입력 예시]
+특약A: "임차인 퇴거 시 모든 원상복구 비용은 임차인이 전액 부담한다."
+특약B: "임차 기간 중 발생하는 모든 수리 및 수선은 임차인이 부담한다."
+특약C: "계약 갱신 시 임대료 인상률은 당사자 간 협의로 정하며 별도 제한을 두지 않는다."
+특약D: "임차인은 계약 만료 시 계약갱신을 요구하지 않기로 한다."
+
+[출력 예시 JSON 내부 구조]
+"contract_checklist": [
+  {{
+    "item": "원상복구 범위 및 귀책 기준 확인",
+    "description": "원상복구 의무의 범위는 임대 당시 목적물의 상태, 계약 체결 경위, 임차인이 수리하거나 변경한 내용 등을 개별적으로 고려하여 정해집니다. 계약 체결 전 또는 입주 시 임차 목적물의 현재 상태를 사진이나 영상으로 기록하고, 하자 부위를 계약서에 명기해 두면 퇴거 시 귀책 여부를 확인하는 근거로 활용할 수 있습니다.",
+    "basis": ["특약A"]
+  }}
+],
+"clause_relations": [
+  {{
+    "clause_id": "특약A",
+    "related_clauses": [
+      {{
+        "clause_id": "특약B",
+        "clause_text": null,
+        "relation": "수선의무 부담 특약이 함께 존재하는 경우, 임차인이 임차 기간 중 자비로 수선한 부분이 퇴거 시 원상복구 대상에 해당하는지 여부가 불명확해집니다. 임차인이 수선 비용을 이미 부담한 부분에 대해 추가로 원상복구 비용까지 청구될 수 있는지를 두 조항을 함께 확인합니다."
+      }}
+    ]
+  }}
+]
+---
+
+JSON 외 텍스트, 마크다운 코드블록은 포함하지 마세요.
+
+{output_format}
+"""
+
+
+def call_llm(
+    prompt: str,
+    schema: type[BaseModel] | None = None,
+    max_retries: int = 2,
+    model_override: str | None = None,
+) -> dict | None:
+    import time
+    from json import JSONDecodeError
+    from pydantic import ValidationError
+
+    model_to_use = model_override if model_override else MODEL_NAME_FLASH
+    model = GenerativeModel(model_to_use, system_instruction=SYSTEM_PROMPT)
+    config = GenerationConfig(temperature=0.0, response_mime_type="application/json")
+
+    for attempt in range(1, max_retries + 2):
+        try:
+            response = model.generate_content(prompt, generation_config=config)
+            text = response.text.strip()
+            text = re.sub(r"^```(?:json)?\s*", "", text)
+            text = re.sub(r"\s*```$", "", text)
+            parsed = json.loads(text)
+            if schema:
+                validated = schema.model_validate(parsed)
+                return validated.model_dump()
+            return parsed
+        except JSONDecodeError as e:
+            print(f"  [call_llm] JSON 파싱 실패 (시도 {attempt}/{max_retries + 1}): {e}")
+        except ValidationError as e:
+            print(f"  [call_llm] Pydantic 검증 실패 (시도 {attempt}/{max_retries + 1}): {e}")
+        except Exception as e:
+            print(f"  [call_llm] LLM 호출 오류 (시도 {attempt}/{max_retries + 1}): {e}")
+
+        if attempt <= max_retries:
+            time.sleep(2 ** attempt)
+
+    return None
+
+from functools import lru_cache
+
+# ... (imports)
+
+# ... (rest of the file)
+
+@lru_cache(maxsize=1024)
+def generate_clause_summary(target_clause: str, laws_json: str, precs_json: str) -> list[dict]:
+    """1단계: 개별 특약의 법령/판례 요약만 생성 (독립적, 비동기 호출용)"""
+    laws = json.loads(laws_json)
+    precs = json.loads(precs_json)
+    
+    prompt = build_clause_summary_prompt(target_clause, laws, precs)
+    result = call_llm(prompt, schema=ClauseSummaryOutput, model_override=MODEL_NAME_FLASH_LITE)
+    
+    rag_map: dict[str, dict] = {}
+    for m in laws:
+        did = m.get("doc_id", "")
+        if did: rag_map[did] = {"type": LawType.law.value, "ref": did, "content": m.get("content") or m.get("doc_text") or ""}
+    for m in precs:
+        did = m.get("doc_id", "")
+        if did: rag_map[did] = {"type": LawType.case.value, "ref": did, "content": m.get("content") or m.get("summary") or ""}
+
+    related_laws = []
+    if result:
+        covered = set()
+        for sel in result.get("selected_laws", []):
+            ref = (sel.get("ref") or "").strip()
+            if ref in rag_map and ref not in covered:
+                related_laws.append({**rag_map[ref], "summary": sel.get("summary")})
+                covered.add(ref)
+
+    return related_laws
+
+
+def generate_final_report(property_info: dict, common_terms: list, clauses_with_hits_and_summaries: list[dict]) -> FinalReportOutput:
+    """2단계: 전체가 모인 후 통합 체크리스트와 연관성 분석 수행"""
+    prompt = build_final_report_prompt(property_info, common_terms, clauses_with_hits_and_summaries)
+    result = call_llm(prompt, schema=FinalReportLLMOutput, model_override=MODEL_NAME_FLASH)
+    
+    if not result:
+        return FinalReportOutput()
+
+    clause_text_map: dict[str, str] = {}
+    for item in clauses_with_hits_and_summaries:
+        label = f"특약{item['index'] - COMMON_TERMS_COUNT}"
+        clause_text_map[label] = item["clause"]
+    for i, term in enumerate(common_terms):
+        clause_text_map[f"공통특약 {i + 1}"] = term
+
+    relations_map = {}
+    
+    # 중복 제거 로직 포함 (A->B, B->A)
+    seen_pairs = set()
+
+    for cr in result.get("clause_relations", []):
+        cid = cr.get("clause_id")
+        if not cid: continue
+        
+        valid_rels = []
+        for rel in cr.get("related_clauses", []):
+            other_id = rel.get("clause_id")
+            if not other_id: continue
+            
+            pair = frozenset([cid, other_id])
+            if pair not in seen_pairs:
+                seen_pairs.add(pair)
+                rel["clause_text"] = clause_text_map.get(other_id)
+                valid_rels.append(rel)
+        
+        if valid_rels:
+            relations_map[cid] = valid_rels
+
+    return FinalReportOutput(
+        contract_checklist=result.get("contract_checklist", []),
+        related_clauses_map=relations_map
+    )

--- a/pipeline/preprocessing/rule_parser.py
+++ b/pipeline/preprocessing/rule_parser.py
@@ -40,9 +40,14 @@ def _cells(line: str) -> list[str]:
 
 
 def _find_row(text: str, label: str) -> list[str]:
+    # 레이블의 각 글자 사이에 공백이 있을 수 있음을 고려한 정규식 생성
+    pattern = re.compile(r"\s*".join(re.escape(c) for l in label.split() for c in l))
     for line in text.splitlines():
-        if line.strip().startswith("|") and label in line:
-            return _cells(line)
+        if line.strip().startswith("|") and pattern.search(line):
+            cells = _cells(line)
+            # 데이터 행은 최소 2개 이상의 셀을 가짐 (제1조 등 제목 행 제외)
+            if len(cells) > 1:
+                return cells
     return []
 
 
@@ -89,17 +94,44 @@ def _date(text: str) -> str | None:
 
 
 def _checked(text: str, label: str) -> bool:
-    pattern = rf"[☑■✓]\s*{re.escape(label)}"
+    # 레이블의 각 글자 사이에 공백이 있을 수 있음을 고려
+    label_pattern = r"\s*".join(re.escape(c) for l in label.split() for c in l)
+    # ☑, ■, ✓ 외에도 ☒, [x], [v], V, v, X, x, O, o, * 등 다양한 체크 기호 대응
+    pattern = rf"(?:[☑■✓☒vVxXOo*]|\[[xXvV*]\])\s*{label_pattern}"
     return re.search(pattern, text) is not None
 
 
 def _lease_type(text: str) -> str:
+    # 1. 기존 체크박스 방식 시도 (가장 명확한 경우)
     if _checked(text, "보증금 있는 월세"):
         return "보증금있는월세"
     if _checked(text, "전세"):
         return "전세"
     if _checked(text, "월세"):
         return "월세"
+
+    # 여러 개의 '차임' 또는 '월세' 행 중 실데이터(숫자)가 포함된 행을 우선적으로 찾음
+    target_labels = ["차임", "월세"]
+    rent_content = ""
+    
+    for label in target_labels:
+        # 모든 라인을 검사하여 숫자가 있는 첫 번째 관련 행을 찾음
+        pattern = re.compile(r"\s*".join(re.escape(c) for c in label))
+        for line in text.splitlines():
+            if line.strip().startswith("|") and pattern.search(line):
+                cells = _cells(line)
+                if len(cells) > 1:
+                    content = " ".join(cells[1:]).strip()
+                    if re.search(r"\d", content):
+                        return "월세"
+                    if not rent_content: # 숫자가 없더라도 첫 번째로 발견된 내용은 저장
+                        rent_content = content
+
+    # 3. 폴백 (전세): '차임' 계열 행에 숫자가 없고(위에서 안 걸림), '전세' 키워드가 있는 경우
+    if ("전세" in text or "전세금" in text) and \
+       (not rent_content or any(word in rent_content for word in ["없음", "0", "-", "해당없음"])):
+        return "전세"
+
     raise RuleParseError("lease_type not found")
 
 

--- a/pipeline/retrieval/query_expansion/query_expansion.py
+++ b/pipeline/retrieval/query_expansion/query_expansion.py
@@ -350,6 +350,7 @@ def build_repair_prompt(
     return base
 
 
+@lru_cache(maxsize=1024)
 def expand_clause(
     clause_text: str,
     *,

--- a/shared/config.py
+++ b/shared/config.py
@@ -76,7 +76,7 @@ class Settings(BaseSettings):
     gcs_bucket: str
 
     # ---- Models (선택값, 기본값 존재) ----
-    gemini_model: str = "gemini-2.5-flash"
+    gemini_model: str = "gemini-2.5-flash-lite"
 
     # ---- Document AI (Document OCR processor) ----
     docai_location: str

--- a/shared/db/connection.py
+++ b/shared/db/connection.py
@@ -71,8 +71,8 @@ class DBClient:
         return sqlalchemy.create_engine(
             "postgresql+pg8000://",
             creator=self._getconn,
-            pool_size=5,
-            max_overflow=2,
+            pool_size=30,
+            max_overflow=10,
             pool_timeout=30,
             pool_recycle=1800,
         )


### PR DESCRIPTION
📝 변경 사항

1. 전처리 엔진 (Preprocessing) 및 파서 개선
- 임대차 유형 판별 로직 강화: 체크박스 기호가 모호(☐)하거나 금액이 한글(오십만원)로 적힌 경우에도 '입금계좌' 내 숫자나
'납부일' 데이터를 분석하여 월세/전세를 스마트하게 판별하는 폴백 로직을 구현했습니다.
- OCR 오차 대응: [x], v, * 등 다양한 체크 기호 인식 및 레이블 내 공백(차 임) 허용 정규식을 적용했습니다.
- PII 마스킹 강화: '임차할 부분' 행에 대한 마스킹 패턴을 추가하여 개인정보 보호를 강화했습니다.

2. API 서버 안정화 및 스키마 확장
- 500/CORS 에러 해결: 상위 6개 공통 특약 분석 시 발생하던 NameError를 해결하고, 분석 제외 항목에 대해 유효한 빈 스키마
객체를 반환하도록 수정하여 API 안정성을 확보했습니다.
- API 스키마 추가: V2 비동기 파이프라인 및 보고서 생성을 위한 요청/응답 스키마(ReportV2Request, ClauseAnalysisV2Response
등)를 정의했습니다.

3. LLM 프롬프트 최적화 및 모델 분리
- 환각(Hallucination) 방지: 제공된 법령/판례 리스트 외의 정보 언급을 엄격히 금지하고, 가장 관련성이 높은 상위 3개 항목만
선별하도록 프롬프트를 강화했습니다.
- 모델 최적화: 법령 설명문 작성에는 flash-lite를, 고부하 연관성 분석에는 flash 모델을 사용하도록 분리하여 속도와 비용을
최적화했습니다.

4. 프론트엔드 UI/UX 개선
- 알림 시스템 개선: 알림 10초 후 자동 삭제 기능을 구현하고, 5개 초과 시 알림이 한 번에 사라지지 않고 하나씩 순차적으로
제거되도록 로직을 개선했습니다.
- 원문 보기 토글 추가: 법령 원문 및 판례 판결 요지를 직접 확인할 수 있는 토글을 추가하고, 사용자 피드백을 반영하여 분석
텍스트 상단에 배치했습니다.

---

🔗 관련 이슈
closes #118

---

🧪 테스트
- [x] '☐' 박스만 있는 실제 계약서 PDF를 통한 lease_type 판별 테스트 완료
- [x] 공통 특약(0~5번) 분석 시 500 에러 발생 여부 및 정상 응답 확인
- [x] 6개 이상의 알림 발생 시 순차 삭제 동작 확인
- [x] LLM 응답 내 검색 결과 외의 법령 포함 여부(환각) 점검

---

✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] 문서를 업데이트했습니다 (해당되는 경우).

---

💬 리뷰어에게
- app/main.py에서 ClauseQueryExpansion 임포트 위치가 변경되었으니 확인 부탁드립니다.
- report_generator_v2.py의 프롬프트 제약이 매우 강해졌으므로, 실제 결과에서 관련 법령이 너무 적게 나오지 않는지 검토가
필요합니다.