### PR TITLE
[Refactor] 분석 페이지 UI 간소화 및 문서 패널 디자인 통일 (#126)

### DIFF
--- a/frontend/app/analysis/page.tsx
+++ b/frontend/app/analysis/page.tsx
@@ -5,7 +5,8 @@ import { TopNavBar } from "@/components/TopNavBar";
 import { DocumentPanel } from "@/components/analysis/DocumentPanel";
 import { LawSection } from "@/components/analysis/LawSection";
 import { PrecedentSection } from "@/components/analysis/PrecedentSection";
-import { BottomActionBar } from "@/components/analysis/BottomActionBar";
+// import { BottomActionBar } from "@/components/analysis/BottomActionBar";
+import { ChatBot } from "@/components/analysis/ChatBot";
 import type { LawItem } from "@/components/analysis/LawSection";
 import type { PrecedentItem } from "@/components/analysis/PrecedentSection";
 import { Loader2, AlertCircle, ChevronDown, X } from "lucide-react";
@@ -67,6 +68,7 @@ export default function AnalysisPage() {
   const [reportData, setReportData] = useState<FinalReportOutput | null>(null);
   const [reportStatus, setReportStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
   const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [isChatOpen, setIsChatOpen] = useState(false);
 
   // 알림 관리 (최대 5개, 초과 시 순차 제거)
   useEffect(() => {
@@ -535,7 +537,7 @@ export default function AnalysisPage() {
                       {llmLaws.length > 0 && (
                         <details className="group/laws border border-blue-200 rounded-lg overflow-hidden">
                           <summary className="flex items-center justify-between text-sm font-semibold text-blue-900 bg-blue-50 px-4 py-3 cursor-pointer hover:bg-blue-100 select-none list-none">
-                            <span>관련 법령</span>
+                            <span>관련된 법령</span>
                             <ChevronDown className="w-4 h-4 text-blue-400 transition-transform rotate-180 group-open/laws:rotate-0" />
                           </summary>
                           <div className="flex flex-col gap-4 p-4 bg-white border-t border-blue-100">
@@ -582,7 +584,7 @@ export default function AnalysisPage() {
                       {llmPrecs.length > 0 && (
                         <details className="group/precs border border-green-200 rounded-lg overflow-hidden">
                           <summary className="flex items-center justify-between text-sm font-semibold text-green-900 bg-green-50 px-4 py-3 cursor-pointer hover:bg-green-100 select-none list-none">
-                            <span>관련 판례</span>
+                            <span>유사한 분쟁 사례</span>
                             <ChevronDown className="w-4 h-4 text-green-400 transition-transform rotate-180 group-open/precs:rotate-0" />
                           </summary>
                           <div className="flex flex-col gap-4 p-4 bg-white border-t border-green-100">
@@ -630,7 +632,7 @@ export default function AnalysisPage() {
                       {reportStatus === "done" && llmRelatedClauses.length > 0 && (
                         <details className="group/rel border border-orange-200 rounded-lg overflow-hidden">
                           <summary className="flex items-center justify-between text-sm font-semibold text-orange-900 bg-orange-50 px-4 py-3 cursor-pointer hover:bg-orange-100 select-none list-none">
-                            <span>다른 특약과의 연관성 주의</span>
+                            <span>함께 확인해야 할 특약</span>
                             <ChevronDown className="w-4 h-4 text-orange-400 transition-transform rotate-180 group-open/rel:rotate-0" />
                           </summary>
                           <div className="flex flex-col gap-4 p-4 bg-white border-t border-orange-100">
@@ -648,7 +650,7 @@ export default function AnalysisPage() {
                     </div>
                   )}
 
-                  {/* 분석 결과 (로딩 완료 시에만) */}
+                  {/* 분석 결과 (로딩 완료 시에만) - 관련 법령/판례 20개 표시 부분 제거 요청으로 주석 처리
                   {clauseResults[idx]?.status !== "loading" && (
                     <div className="flex flex-col gap-8 pt-4 border-t border-gray-100">
                       {clauseResults[idx].laws.length > 0 ? (
@@ -662,6 +664,7 @@ export default function AnalysisPage() {
                       )}
                     </div>
                   )}
+                  */}
                         </div>
                       </details>
                     </div>
@@ -679,7 +682,22 @@ export default function AnalysisPage() {
         </section>
       </div>
 
-      <BottomActionBar />
+      {/* <BottomActionBar onChatbot={() => setIsChatOpen(true)} /> */}
+      
+      {/* 챗봇 컴포넌트 */}
+      <ChatBot 
+        isOpen={isChatOpen}
+        onOpen={() => setIsChatOpen(true)}
+        onClose={() => setIsChatOpen(false)}
+        context={{
+          report: reportData,
+          clauses: Object.values(clauseResults).map(res => ({
+            laws: res.llmRelatedLaws,
+            status: res.status
+          })),
+          rawContract: typeof window !== "undefined" ? JSON.parse(sessionStorage.getItem("ade.analysis.contract") || "{}") : null
+        }}
+      />
     </div>
   );
 }

--- a/frontend/components/TopNavBar.tsx
+++ b/frontend/components/TopNavBar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Bell, Settings, User } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 export type NavTab = "analysis" | "chatbot";
@@ -81,53 +80,11 @@ export function TopNavBar({
           )}
         </div>
 
-        {/* Center: Pill tabs */}
-        <div
-          className="inline-flex shrink-0 justify-self-center rounded-lg p-0.5"
-          style={{ background: "rgba(255,255,255,0.1)" }}
-        >
-          {(["analysis", "chatbot"] as NavTab[]).map((tab) => {
-            const label = tab === "analysis" ? "계약서 분석" : "AI 챗봇";
-            const isActive = tab === activeTab;
-            return (
-              <button
-                key={tab}
-                type="button"
-                className={`${tabBase} ${isActive ? tabActive : tabInactive}`}
-                style={{ fontFamily: "var(--font-alexandria)" }}
-                onClick={() => onTabChange?.(tab)}
-                aria-pressed={isActive}
-              >
-                {label}
-              </button>
-            );
-          })}
-        </div>
+        {/* Center: Empty (Removed) */}
+        <div />
 
-        {/* Right: Icon buttons */}
-        <div className="flex items-center gap-1 justify-self-end border-l border-white/0 pl-0 sm:border-white/15 sm:pl-3">
-          <button
-            type="button"
-            className="rounded-md p-2 text-white/80 transition hover:bg-white/10 hover:text-white"
-            aria-label="알림"
-          >
-            <Bell className="h-5 w-5" />
-          </button>
-          <button
-            type="button"
-            className="rounded-md p-2 text-white/80 transition hover:bg-white/10 hover:text-white"
-            aria-label="설정"
-          >
-            <Settings className="h-5 w-5" />
-          </button>
-          <button
-            type="button"
-            className="rounded-md p-2 text-white/80 transition hover:bg-white/10 hover:text-white"
-            aria-label="프로필"
-          >
-            <User className="h-5 w-5" />
-          </button>
-        </div>
+        {/* Right: Empty (Removed) */}
+        <div />
       </div>
     </header>
   );

--- a/frontend/components/analysis/DocumentPanel.tsx
+++ b/frontend/components/analysis/DocumentPanel.tsx
@@ -159,10 +159,12 @@ export function DocumentPanel({
               {specialTerms.slice(0, 6).map((text, i) => (
                 <div
                   key={`common-${i}`}
-                  className="flex flex-col gap-1 rounded-lg border border-gray-100 bg-gray-50/50 p-3 text-left"
+                  className="flex flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4 text-left"
                 >
-                  <span className="text-[9px] font-bold text-gray-300 uppercase">공통특약 {i + 1}</span>
-                  <div className="text-xs text-gray-600 leading-relaxed font-medium">
+                  <span className="text-[10px] font-bold text-gray-400 uppercase">
+                    공통특약 {i + 1}
+                  </span>
+                  <div className="text-sm text-gray-800 leading-relaxed font-medium">
                     <ReactMarkdown 
                       remarkPlugins={[remarkGfm]}
                       components={MarkdownComponents}
@@ -187,17 +189,15 @@ export function DocumentPanel({
             </h3>
             <div className="flex flex-col gap-4">
               {generalTerms.map((term, i) => (
-                <div key={i} className="flex flex-col gap-1 px-2">
-                  <p className="text-xs font-bold text-gray-500">{term.title}</p>
-                  <div className="p-3 border rounded bg-white border-gray-100 overflow-hidden">
-                    <div className="text-xs text-gray-600 leading-relaxed">
-                      <ReactMarkdown 
-                        remarkPlugins={[remarkGfm]}
-                        components={MarkdownComponents}
-                      >
-                        {preprocessMarkdown(term.text)}
-                      </ReactMarkdown>
-                    </div>
+                <div key={i} className="flex flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4 text-left">
+                  <span className="text-[10px] font-bold text-gray-400 uppercase">{term.title}</span>
+                  <div className="text-sm text-gray-800 leading-relaxed font-medium">
+                    <ReactMarkdown 
+                      remarkPlugins={[remarkGfm]}
+                      components={MarkdownComponents}
+                    >
+                      {preprocessMarkdown(term.text)}
+                    </ReactMarkdown>
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
## 📝 변경 사항
- **UI 간소화:** 상단 네비게이션 바의 불필요한 탭과 아이콘을 제거하고, 하단 액션 바를 삭제하여 대시보드형 레이아웃으로 개편했습니다.
- **디자인 시스템 통일:** 좌측 문서 패널의 '공통 특약' 및 '일반 조항'을 주 '특약 사항'과 동일한 카드 스타일로 리팩토링하여 시각적 일관성을 확보했습니다.
- **정보 계층화:** 특약 분석 결과 하단에 나열되던 20여 개의 법령/판례 원문 리스트를 숨김 처리하여 사용자가 LLM 요약 정보에 집중할 수 있도록 개선했습니다.

## 🔗 관련 이슈
closes #126 

## 🧪 테스트
- [x] 좌측 패널의 모든 섹션 디자인이 동일한 카드 스타일로 표시되는지 확인
- [x] 상단바/하단바 제거 후 전체 페이지 레이아웃 및 스크롤 동작 확인
- [x] 특약 분석 결과 펼침/접힘 시 요약 정보가 가독성 있게 노출되는지 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작합니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 셀프 리뷰를 완료했습니다.
- [x] UI 변경 사항에 대한 검증을 완료했습니다.
