### PR TITLE
[Feature] 특약 재작성 및 분석/챗봇 기능 고도화 (#130)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,12 +47,14 @@ from app.schemas import (
     RetrievalResponse,
     ChatRequest,
     ChatResponse,
+    ClauseRewriteRequest,
+    ClauseRewriteResponse,
 )
 from pipeline.preprocessing.schema import LeaseContract
 from pipeline.retrieval.query_expansion.query_expansion_schema import ClauseQueryExpansion
 from pipeline.retrieval.retrieval_service import retrieval_service
 from pipeline.generation.report_generator import generate_report_from_data, ReportOutput
-from pipeline.generation.report_generator_v2 import generate_clause_summary, generate_final_report, FinalReportOutput, COMMON_TERMS_COUNT
+from pipeline.generation.report_generator_v2 import generate_clause_summary, generate_final_report, generate_clause_rewrite, FinalReportOutput, COMMON_TERMS_COUNT
 from shared.db.connection import get_db_client
 from shared.storage.gcs_client import get_gcs_client
 
@@ -228,6 +230,47 @@ async def get_parsed_document(doc_id: str, client_id: str):
         raise HTTPException(status_code=404, detail="과거 분석 데이터를 찾을 수 없습니다.")
 
 
+@app.delete("/api/documents/{doc_id}")
+async def delete_document(doc_id: str, client_id: str):
+    """DB와 GCS에서 문서 데이터를 영구 삭제한다."""
+    db = get_db_client()
+    gcs = get_gcs_client()
+
+    # 1. 문서 존재 여부 확인 및 경로 확보
+    row = db.fetch_one(
+        text("SELECT doc_id FROM document_history WHERE doc_id = :doc_id AND client_id = :client_id"),
+        {"doc_id": doc_id, "client_id": client_id}
+    )
+
+    if not row:
+        raise HTTPException(status_code=404, detail="삭제할 문서를 찾을 수 없습니다.")
+
+    # 2. GCS 파일 삭제
+    # 업로드 시 blob_name 형식: raw: f"clients/{client_id}/raw/{doc_id}.pdf", parsed: f"clients/{client_id}/parsed/{doc_id}.json"
+    raw_blob = f"clients/{client_id}/raw/{doc_id}.pdf"
+    parsed_blob = f"clients/{client_id}/parsed/{doc_id}.json"
+
+    try:
+        if gcs.exists(raw_blob):
+            gcs.delete(raw_blob)
+        if gcs.exists(parsed_blob):
+            gcs.delete(parsed_blob)
+    except Exception as e:
+        log.warning(f"GCS 파일 일부 삭제 실패 (doc={doc_id}): {e}")
+
+    # 3. DB 레코드 삭제
+    try:
+        db.execute(
+            text("DELETE FROM document_history WHERE doc_id = :doc_id AND client_id = :client_id"),
+            {"doc_id": doc_id, "client_id": client_id}
+        )
+    except Exception as e:
+        log.error(f"DB 레코드 삭제 실패 (doc={doc_id}): {e}")
+        raise HTTPException(status_code=500, detail="데이터베이스 삭제 중 오류가 발생했습니다.")
+
+    return {"message": "문서가 성공적으로 삭제되었습니다."}
+
+
 @app.post("/api/analyze/clause", response_model=ClauseAnalysisResponse)
 async def analyze_single_clause(request: AnalyzeClauseRequest) -> ClauseAnalysisResponse:
     """단일 특약에 대해 쿼리 확장 -> 하이브리드 검색 -> 리랭킹 파이프라인을 실행한다."""
@@ -304,11 +347,14 @@ async def analyze_single_clause_v2(request: AnalyzeClauseRequest) -> ClauseAnaly
         laws_json = json.dumps(laws_dict, sort_keys=True)
         precs_json = json.dumps(precs_dict, sort_keys=True)
         return generate_clause_summary(request.clause_text, laws_json, precs_json)
-    
-    llm_related_laws = await _run_in_executor(_run_llm_summary)
+
+    llm_result = await _run_in_executor(_run_llm_summary)
+    clause_one_line_summary = llm_result.get("clause_one_line_summary", "") if llm_result else ""
+    clause_interpretation = llm_result.get("clause_interpretation", "") if llm_result else ""
+    llm_related_laws = llm_result.get("related_laws", []) if llm_result else []
 
     # 5. 상세 결과에 LLM 분석 내용(이유/위배여부) 매핑
-    # llm_related_laws 는 [{"ref": "...", "summary": "...", "is_violation": bool, ...}] 형태
+    # llm_related_laws: [{"ref", "type", "content", "summary", "is_violation", "is_caution"}]
     summary_map = {item["ref"]: item for item in llm_related_laws}
     
     for doc in law_results:
@@ -329,6 +375,8 @@ async def analyze_single_clause_v2(request: AnalyzeClauseRequest) -> ClauseAnaly
         law_results=law_results,
         prec_results=prec_results,
         llm_related_laws=llm_related_laws,
+        clause_one_line_summary=clause_one_line_summary or None,
+        clause_interpretation=clause_interpretation or None,
     )
 
 
@@ -344,6 +392,24 @@ async def analyze_report_v2(request: ReportV2Request) -> FinalReportOutput:
         )
 
     return await _run_in_executor(_run_final_report_gen)
+
+
+@app.post("/api/analyze/rewrite_clause", response_model=ClauseRewriteResponse)
+async def rewrite_clause(request: ClauseRewriteRequest) -> ClauseRewriteResponse:
+    """위반 가능성이 있는 특약을 법령에 맞게 재작성한다."""
+    def _run_rewrite():
+        return generate_clause_rewrite(
+            original_clause=request.clause_text,
+            violation_laws=request.violation_laws,
+            all_related_laws=request.all_related_laws,
+        )
+
+    result = await _run_in_executor(_run_rewrite)
+    return ClauseRewriteResponse(
+        rewritten_clause=result.get("rewritten_clause", ""),
+        reason=result.get("reason", ""),
+    )
+
 
 # ──────────────────────────────────────────────────────────────────────
 # 기존 (레거시) API 들 - 필요시 삭제 가능
@@ -683,56 +749,57 @@ def search_legal_info(query: str) -> dict:
     from pipeline.retrieval.query_expansion.retrieval_adapter import build_retrieval_payload
     from pipeline.retrieval.retrieval_service import retrieval_service
     
-    # 1. 쿼리 확장 및 페이로드 구성
-    expansion = expand_clause(query)
-    payload = build_retrieval_payload(expansion, clause_text=query)
+    if not retrieval_service.is_ready:
+        log.error("search_legal_info: RetrievalService가 아직 준비되지 않았습니다.")
+        return {"laws": [], "precedents": []}
     
-    # 2. 하이브리드 검색 수행
-    res = retrieval_service.retrieve(payload)
-    
-    # 3. 각 검색 방식의 상위 결과 추출 및 통합 (중복 제거)
-    # BM25 상위 결과
-    bm25_law_ids = [hit["doc_id"] for hit in res["bm25"] if hit["source_type"] == "law"][:5]
-    bm25_prec_ids = [hit["doc_id"] for hit in res["bm25"] if hit["source_type"] == "precedent"][:5]
-    
-    # Semantic(Dense) 상위 결과
-    dense_law_ids = [hit["doc_id"] for hit in res["dense"] if hit["source_type"] == "law"][:5]
-    dense_prec_ids = [hit["doc_id"] for hit in res["dense"] if hit["source_type"] == "precedent"][:5]
-    
-    # 통합 및 순서 유지 중복 제거
-    law_ids = list(dict.fromkeys(bm25_law_ids + dense_law_ids))
-    prec_ids = list(dict.fromkeys(bm25_prec_ids + dense_prec_ids))
-    
-    # 최종 상위 N개로 제한 (컨텍스트 크기 관리)
-    law_ids = law_ids[:8]
-    prec_ids = prec_ids[:8]
-    
-    laws_content = _fetch_law_content(law_ids)
-    precs_content = _fetch_prec_content(prec_ids)
-    
-    # 4. 결과 정리
-    final_laws = []
-    for lid in law_ids:
-        if lid in laws_content:
-            c = laws_content[lid]
-            final_laws.append({
-                "title": f"{c.get('law_name')} 제{c.get('article_no')}조",
-                "content": c.get("child_text") or c.get("parent_text")
-            })
-            
-    final_precs = []
-    for pid in prec_ids:
-        if pid in precs_content:
-            c = precs_content[pid]
-            final_precs.append({
-                "title": c.get("case_name") or pid,
-                "content": c.get("judgment_summary") or c.get("issue")
-            })
-            
-    return {
-        "laws": final_laws,
-        "precedents": final_precs
-    }
+    try:
+        # 1. 쿼리 확장 및 페이로드 구성
+        expansion = expand_clause(query)
+        payload = build_retrieval_payload(expansion, clause_text=query)
+        
+        # 2. 하이브리드 검색 수행
+        res = retrieval_service.retrieve(payload)
+        
+        # 3. 각 검색 방식의 상위 결과 추출 및 통합 (중복 제거)
+        bm25_law_ids = [hit["doc_id"] for hit in res["bm25"] if hit["source_type"] == "law"][:5]
+        bm25_prec_ids = [hit["doc_id"] for hit in res["bm25"] if hit["source_type"] == "precedent"][:5]
+        
+        dense_law_ids = [hit["doc_id"] for hit in res["dense"] if hit["source_type"] == "law"][:5]
+        dense_prec_ids = [hit["doc_id"] for hit in res["dense"] if hit["source_type"] == "precedent"][:5]
+        
+        law_ids = list(dict.fromkeys(bm25_law_ids + dense_law_ids))[:8]
+        prec_ids = list(dict.fromkeys(bm25_prec_ids + dense_prec_ids))[:8]
+        
+        laws_content = _fetch_law_content(law_ids)
+        precs_content = _fetch_prec_content(prec_ids)
+        
+        # 4. 결과 정리
+        final_laws = []
+        for lid in law_ids:
+            if lid in laws_content:
+                c = laws_content[lid]
+                final_laws.append({
+                    "title": f"{c.get('law_name')} 제{c.get('article_no')}조",
+                    "content": c.get("child_text") or c.get("parent_text")
+                })
+                
+        final_precs = []
+        for pid in prec_ids:
+            if pid in precs_content:
+                c = precs_content[pid]
+                final_precs.append({
+                    "title": c.get("case_name") or pid,
+                    "content": c.get("judgment_summary") or c.get("issue")
+                })
+                
+        return {
+            "laws": final_laws,
+            "precedents": final_precs
+        }
+    except Exception as e:
+        log.error(f"search_legal_info 실행 중 오류 발생: {e}")
+        return {"laws": [], "precedents": []}
 
 
 @app.post("/api/chat", response_model=ChatResponse)
@@ -743,16 +810,21 @@ async def chat(request: ChatRequest) -> ChatResponse:
     from google.genai import types
     
     system_instruction = (
-        "당신은 부동산 계약 전문 분석 AI 'ADE'입니다.\n"
+        "당신은 부동산 계약 전문 분석 AI 'CLARA'입니다.\n"
         "제공된 정보를 바탕으로 사용자의 질문에 답변하세요.\n"
         "참고 가능한 정보는 다음과 같습니다:\n"
         "1. **파싱된 원본 문서**: 계약서의 전체 조항과 특약 사항 원문입니다.\n"
         "2. **분석 리포트**: AI가 분석한 핵심 체크리스트와 각 특약별 법적 검토 결과입니다.\n"
-        "3. **대화 히스토리**: 이전 대화 맥락을 파악하여 자연스러운 대화를 이어가세요.\n\n"
-        "추가적인 법률 정보나 판례가 필요하다고 판단되면 'search_legal_info' 도구를 사용하여 DB를 검색하세요.\n"
+        "3. **재작성된 특약(rewrittenClauses)**: 법령 위배 가능성이 있는 특약에 대해 사용자가 재작성을 요청한 경우, 수정된 특약 원문과 재작성 이유가 포함됩니다. 사용자가 재작성된 특약에 대해 물어볼 경우 이 데이터를 우선 참고하세요.\n"
+        "4. **대화 히스토리**: 이전 대화 맥락을 파악하여 자연스러운 대화를 이어가세요.\n"
+        "4. **특약 번호 규칙 (반드시 준수)**: 화면에서 특약 목록의 첫 6개(인덱스 0~5)는 '공통특약'이고, 7번째(인덱스 6)부터가 '특약'입니다.\n"
+        "   - '특약 N' 또는 'N번 특약' → 공통특약을 **완전히 제외**한 일반 특약의 N번째. 즉 인덱스 (6 + N - 1)번에 해당합니다.\n"
+        "   - '공통특약 N' → 공통 특약의 N번째. 즉 인덱스 (N - 1)번에 해당합니다.\n"
+        "   - **핵심 원칙**: 사용자가 '공통특약'이라는 단어를 명시적으로 말하지 않는 한, '특약'은 절대로 공통특약을 가리키지 않습니다. '특약 2번'은 공통특약 2번이 아니라 인덱스 7번(일반 특약 2번째)입니다.\n\n"
         "답변은 친절하고 전문적이어야 하며, 한국어로 답변하세요.\n"
         "모든 답변은 **Markdown** 문법을 사용하여 가독성 있게 작성하세요.\n"
         "원본 문서와 분석 리포트의 내용이 상충할 경우, 분석 리포트를 우선하되 원문 내용을 함께 인용하세요.\n"
+        "**중요**: 제공된 파싱된 원본 문서 및 분석 리포트에 명시되지 않은 내용(예: 계약서에 없는 일반적인 법률 조항이나 판례에 대한 질문 등)에 대해서는 절대 당신의 내장 지식을 사용하여 추측성 답변(환각)을 하지 마세요. 반드시 '해당 내용은 현재 분석 중인 계약서나 리포트에서 확인할 수 없어 정확한 답변이 어렵습니다.'라고 정중히 거절하세요.\n"
         "확실하지 않은 법률적 판단은 반드시 변호사 등 전문가와 상담할 것을 권고하는 문구를 포함하세요."
     )
     
@@ -786,18 +858,16 @@ async def chat(request: ChatRequest) -> ChatResponse:
     last_user_msg = all_msgs[-1].content
     
     try:
-        # 툴 실행 결과를 가져오기 위해 직접 세션을 관리하거나,
-        # SDK가 제공하는 최종 응답 구조를 파싱해야 함.
         from google.genai import types
         
         async def _chat_with_tools_manual():
-            # 세션 생성 (자동 도구 실행 설정 추가)
+            # 도구 사용 일시 중단 (사용자 요청)
             chat_session = gemini_client._client.chats.create(
                 model=settings.gemini_model,
                 config=types.GenerateContentConfig(
                     system_instruction=full_system_instruction,
-                    tools=[search_legal_info],
-                    automatic_function_calling=types.AutomaticFunctionCallingConfig(disable=False),
+                    # tools=[search_legal_info],
+                    # automatic_function_calling=types.AutomaticFunctionCallingConfig(disable=False),
                     temperature=0.0
                 ),
                 history=history
@@ -807,27 +877,12 @@ async def chat(request: ChatRequest) -> ChatResponse:
             loop = asyncio.get_event_loop()
             response = await loop.run_in_executor(_clause_executor, chat_session.send_message, last_user_msg)
             
-            # 자동 실행이 켜져 있으면 이미 루프가 끝난 상태.
+            # 도구를 사용하지 않으므로 빈 소스 반환
             all_sources = []
-            
-            # chat_session.history에는 [..., User, Model(ToolCall), Tool(ToolResponse), Model(FinalAnswer)] 가 들어있음.
-            # SDK 버전에 따라 history 속성 대신 get_history() 메서드를 사용해야 할 수 있음.
-            for content in reversed(chat_session.get_history()):
-                if content.role == "tool":
-                    for part in content.parts:
-                        if part.function_response:
-                            res_val = part.function_response.response
-                            if isinstance(res_val, dict):
-                                if "laws" in res_val:
-                                    all_sources.extend(res_val["laws"])
-                                if "precedents" in res_val:
-                                    all_sources.extend(res_val["precedents"])
-                if content.role == "user": 
-                    break
                     
             answer_text = "".join([p.text for p in response.candidates[0].content.parts if p.text])
             if not answer_text:
-                answer_text = "검색 결과를 정리해 드립니다."
+                answer_text = "답변을 생성할 수 없습니다."
                 
             return answer_text, all_sources
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -78,6 +78,8 @@ class ClauseAnalysisV2Response(BaseModel):
     law_results: list[RankedDocument]   # 법령 (rank 1~TOP_K, 독립)
     prec_results: list[RankedDocument]  # 판례 (rank 1~TOP_K, 독립)
     llm_related_laws: list[dict]        # LLM 요약 결과
+    clause_one_line_summary: str | None = None  # 한 줄 요약
+    clause_interpretation: str | None = None    # 특약 해석 (일반인용)
 
 class ClauseWithSummary(BaseModel):
     index: int
@@ -186,6 +188,16 @@ class RerankingResponse(BaseModel):
 # ──────────────────────────────────────────────────────────────────────
 # 챗봇용 스키마
 # ──────────────────────────────────────────────────────────────────────
+
+class ClauseRewriteRequest(BaseModel):
+    clause_text: str
+    violation_laws: list[dict]   # is_violation=True 항목
+    all_related_laws: list[dict] # 전체 related_laws
+
+class ClauseRewriteResponse(BaseModel):
+    rewritten_clause: str
+    reason: str
+
 
 class ChatMessage(BaseModel):
     role: str  # "user" or "assistant"

--- a/frontend/app/analysis/page.tsx
+++ b/frontend/app/analysis/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { TopNavBar } from "@/components/TopNavBar";
 import { DocumentPanel } from "@/components/analysis/DocumentPanel";
 import { LawSection } from "@/components/analysis/LawSection";
@@ -27,6 +29,8 @@ type ClauseResult = {
   rawLaws: any[];
   rawPrecs: any[];
   llmRelatedLaws: RelatedLaw[];
+  clauseOneLineSummary?: string;
+  clauseInterpretation?: string;
   status: "loading" | "done" | "error";
 };
 
@@ -42,6 +46,7 @@ type RelatedLaw = {
   summary: string;
   content: string;
   is_violation?: boolean;
+  is_caution?: boolean;
 };
 
 type RelatedClause = {
@@ -69,6 +74,53 @@ export default function AnalysisPage() {
   const [reportStatus, setReportStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [isChatOpen, setIsChatOpen] = useState(false);
+  const [viewTab, setViewTab] = useState<"analysis" | "checklist">("analysis");
+
+  const [openPopover, setOpenPopover] = useState<string | null>(null);
+  const [activeClauseIdx, setActiveClauseIdx] = useState<number | null>(null);
+
+  type RewriteCache = { rewrittenClause: string; reason: string };
+  type RewriteModal = {
+    clauseIdx: number;
+    clauseText: string;
+    violationLaws: RelatedLaw[];
+    allRelatedLaws: RelatedLaw[];
+    status: "loading" | "done" | "error";
+    rewrittenClause?: string;
+    reason?: string;
+  };
+  const [rewriteCache, setRewriteCache] = useState<Record<number, RewriteCache>>(() => {
+    try {
+      const raw = sessionStorage.getItem("ade.rewrite.cache");
+      return raw ? JSON.parse(raw) : {};
+    } catch { return {}; }
+  });
+  const [rewriteModal, setRewriteModal] = useState<RewriteModal | null>(null);
+  const [showChecklistToast, setShowChecklistToast] = useState(false);
+  const checklistTabRef = useRef<HTMLButtonElement>(null);
+  const [toastPos, setToastPos] = useState<{ left: number; top: number } | null>(null);
+
+  // 체크리스트 완료 토스트
+  useEffect(() => {
+    if (reportStatus === "done") {
+      setShowChecklistToast(true);
+    }
+  }, [reportStatus]);
+
+  useEffect(() => {
+    if (showChecklistToast && checklistTabRef.current) {
+      const rect = checklistTabRef.current.getBoundingClientRect();
+      setToastPos({ left: rect.left + rect.width / 2, top: rect.top });
+    }
+  }, [showChecklistToast]);
+
+  const clauseResultsCount = Object.keys(clauseResults).length;
+
+  // 재작성 모달 열릴 때 배경 스크롤 차단
+  useEffect(() => {
+    document.body.style.overflow = rewriteModal ? "hidden" : "";
+    return () => { document.body.style.overflow = ""; };
+  }, [rewriteModal]);
 
   // 알림 관리 (최대 5개, 초과 시 순차 제거)
   useEffect(() => {
@@ -91,6 +143,10 @@ export default function AnalysisPage() {
     const storedDocId = sessionStorage.getItem("ade.analysis.docId");
     const storedContract = sessionStorage.getItem("ade.analysis.contract");
     const clientId = localStorage.getItem("ade.client_id");
+
+    // 새 분석 시작 시 재작성 캐시 초기화
+    sessionStorage.removeItem("ade.rewrite.cache");
+    setRewriteCache({});
 
     if (storedFileName) setFileName(storedFileName);
     
@@ -119,7 +175,7 @@ export default function AnalysisPage() {
 
         const initialResults: Record<number, ClauseResult> = {};
         terms.forEach((_: string, i: number) => {
-          initialResults[i] = { laws: [], precedents: [], rawLaws: [], rawPrecs: [], llmRelatedLaws: [], status: "loading" };
+          initialResults[i] = { laws: [], precedents: [], rawLaws: [], rawPrecs: [], llmRelatedLaws: [], clauseInterpretation: undefined, status: "loading" };
         });
         setClauseResults(initialResults);
 
@@ -184,13 +240,15 @@ export default function AnalysisPage() {
 
               setClauseResults(prev => ({
                 ...prev,
-                [index]: { 
-                  laws: termLaws, 
-                  precedents: termPrecedents, 
-                  rawLaws: data?.law_results ?? [], 
+                [index]: {
+                  laws: termLaws,
+                  precedents: termPrecedents,
+                  rawLaws: data?.law_results ?? [],
                   rawPrecs: data?.prec_results ?? [],
                   llmRelatedLaws: data?.llm_related_laws ?? [],
-                  status: "done" 
+                  clauseOneLineSummary: data?.clause_one_line_summary ?? undefined,
+                  clauseInterpretation: data?.clause_interpretation ?? undefined,
+                  status: "done"
                 }
               }));
 
@@ -285,14 +343,149 @@ export default function AnalysisPage() {
   }, [completedCount, specialTerms.length, clauseResults, reportStatus]);
 
   const handleTermClick = (index: number) => {
-    const element = document.getElementById(`analysis-result-${index}`);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "start" });
+    setViewTab("analysis");
+    setTimeout(() => {
+      const element = document.getElementById(`analysis-result-${index}`);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    }, 50);
+  };
+
+  const handleRewriteClause = async (
+    clauseIdx: number,
+    clauseText: string,
+    violationLaws: RelatedLaw[],
+    allRelatedLaws: RelatedLaw[],
+    forceRefresh = false,
+  ) => {
+    // 캐시 있으면 바로 표시
+    if (!forceRefresh && rewriteCache[clauseIdx]) {
+      const cached = rewriteCache[clauseIdx];
+      setRewriteModal({ clauseIdx, clauseText, violationLaws, allRelatedLaws, status: "done", ...cached });
+      return;
+    }
+    setRewriteModal({ clauseIdx, clauseText, violationLaws, allRelatedLaws, status: "loading" });
+    try {
+      const res = await fetch(`${API_BASE}/api/analyze/rewrite_clause`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          clause_text: clauseText,
+          violation_laws: violationLaws,
+          all_related_laws: allRelatedLaws,
+        }),
+      });
+      if (!res.ok) throw new Error("rewrite failed");
+      const data = await res.json();
+      const result: RewriteCache = { rewrittenClause: data.rewritten_clause, reason: data.reason };
+      setRewriteCache(prev => {
+        const next = { ...prev, [clauseIdx]: result };
+        try { sessionStorage.setItem("ade.rewrite.cache", JSON.stringify(next)); } catch {}
+        return next;
+      });
+      setRewriteModal(prev => prev ? { ...prev, status: "done", ...result } : null);
+    } catch {
+      setRewriteModal(prev => prev ? { ...prev, status: "error" } : null);
     }
   };
 
   return (
     <div className="flex flex-col h-screen overflow-hidden" style={{ background: "#F4F3F7" }}>
+
+      {/* 특약 재작성 팝업 */}
+      {rewriteModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+        >
+          <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden">
+
+            {/* 헤더 */}
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+              <div className="flex items-center gap-2">
+                <h2 className="text-base font-bold text-gray-900">✏️ 특약 재작성 제안</h2>
+                {/* 새로고침 버튼 + tooltip */}
+                {rewriteModal.status !== "loading" && (
+                  <div className="relative group/refresh">
+                    <button
+                      onClick={() => handleRewriteClause(
+                        rewriteModal.clauseIdx,
+                        rewriteModal.clauseText,
+                        rewriteModal.violationLaws,
+                        rewriteModal.allRelatedLaws,
+                        true,
+                      )}
+                      className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-blue-500 transition-colors"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/>
+                      </svg>
+                    </button>
+                    <div className="absolute left-1/2 -translate-x-1/2 top-full mt-1.5 px-2 py-1 rounded bg-gray-800 text-white text-[11px] whitespace-nowrap opacity-0 group-hover/refresh:opacity-100 pointer-events-none transition-opacity z-10">
+                      다시 작성하기
+                      <div className="absolute left-1/2 -translate-x-1/2 -top-1 w-2 h-2 bg-gray-800 rotate-45" />
+                    </div>
+                  </div>
+                )}
+              </div>
+              <button
+                onClick={() => setRewriteModal(null)}
+                className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* 원본 특약 — 고정 */}
+            <div className="shrink-0 px-6 pt-4 pb-4 border-b border-gray-100">
+              <p className="text-sm font-bold text-red-600 mb-1.5 uppercase tracking-wide">원본 특약</p>
+              <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2.5">
+                <p className="text-sm text-red-900 leading-relaxed">
+                  &ldquo;{rewriteModal.clauseText}&rdquo;
+                </p>
+              </div>
+            </div>
+
+            {/* 재작성된 특약 — 고정 (done 상태) */}
+            {rewriteModal.status === "done" && (
+              <div className="shrink-0 px-6 pt-4 pb-4 border-b border-gray-100">
+                <p className="text-sm font-bold text-blue-700 mb-2 uppercase tracking-wide">재작성된 특약</p>
+                <div className="bg-blue-50 border border-blue-200 rounded-xl px-4 py-3">
+                  <p className="text-sm text-gray-900 leading-relaxed whitespace-pre-wrap">
+                    {rewriteModal.rewrittenClause}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* 스크롤 영역 */}
+            {rewriteModal.status === "loading" && (
+              <div className="flex flex-col items-center justify-center gap-4 py-16 px-6">
+                <Loader2 className="w-10 h-10 text-blue-500 animate-spin" />
+                <p className="text-sm font-semibold text-gray-700">특약을 재작성하고 있습니다…</p>
+                <p className="text-xs text-gray-400">관련 법령을 검토하는 중이에요. 약 1분 소요될 수 있습니다.</p>
+              </div>
+            )}
+
+            {rewriteModal.status === "error" && (
+              <div className="flex flex-col items-center justify-center gap-3 py-16 px-6">
+                <AlertCircle className="w-8 h-8 text-red-400" />
+                <p className="text-sm text-gray-600">재작성 중 오류가 발생했습니다. 다시 시도해 주세요.</p>
+              </div>
+            )}
+
+            {rewriteModal.status === "done" && (
+              <div className="overflow-y-auto flex-1 px-6 py-5">
+                <p className="text-sm font-bold text-gray-900 mb-2 uppercase tracking-wide">재작성 이유 및 근거</p>
+                <div className="prose prose-sm max-w-none text-gray-700 prose-li:my-0.5 prose-ul:my-1 prose-p:my-1 [&_strong]:text-gray-900 [&_strong]:font-bold">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{rewriteModal.reason ?? ""}</ReactMarkdown>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
       <TopNavBar
         mode="analysis"
         fileName={`${fileName} ${specialTerms.length > 0 && analysisStatus === "loading" ? `(분석 중: ${completedCount}/${specialTerms.length})` : ""}`}
@@ -330,16 +523,46 @@ export default function AnalysisPage() {
       </div>
 
       <div className="flex flex-row flex-1 min-h-0">
-        <DocumentPanel 
+        <DocumentPanel
           specialTerms={specialTerms}
           generalTerms={generalTerms}
           onTermClick={handleTermClick}
+          activeIdx={activeClauseIdx}
         />
 
         <section
-          className="flex flex-col flex-1 overflow-y-auto px-8 py-8 gap-8"
-          style={{ background: "#FAF9FD", paddingBottom: "128px" }}
+          className="flex flex-col flex-1 overflow-hidden"
+          style={{ background: "#FAF9FD" }}
         >
+          {/* 탭 바 */}
+          <div className="px-8 pt-8 pb-0" style={{ background: "#FAF9FD" }}>
+            <div className="flex gap-1 p-1 rounded-xl bg-gray-100 self-start inline-flex">
+              {(["analysis", "checklist"] as const).map((tab) => (
+                <button
+                  key={tab}
+                  ref={tab === "checklist" ? checklistTabRef : undefined}
+                  onClick={() => { setViewTab(tab); if (tab === "checklist") setShowChecklistToast(false); }}
+                  className={`px-5 py-2 rounded-lg text-sm font-semibold transition-all ${
+                    viewTab === tab
+                      ? "bg-white text-gray-900 shadow-sm"
+                      : "text-gray-500 hover:text-gray-700"
+                  }`}
+                >
+                  {tab === "analysis" ? "특약 분석" : "체크리스트"}
+                  {tab === "checklist" && reportStatus === "loading" && (
+                    <Loader2 className="inline-block ml-1.5 h-3 w-3 animate-spin text-blue-500" />
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* 스크롤 가능한 콘텐츠 영역 */}
+          <div className="flex flex-col flex-1 overflow-y-auto px-8 pt-8 gap-8" style={{ paddingBottom: "128px" }}>
+
+          {/* 체크리스트 탭 */}
+          {viewTab === "checklist" && (
+            <>
           {/* 종합 체크리스트 렌더링 */}
           {reportStatus === "loading" && (
             <div className="flex flex-col gap-4 p-6 rounded-xl border bg-blue-50/50 shadow-sm border-blue-100">
@@ -369,20 +592,33 @@ export default function AnalysisPage() {
                 <ChevronDown className="w-5 h-5 text-gray-400 transition-transform rotate-180 group-open:rotate-0 ml-auto" />
               </summary>
               <div className="flex flex-col gap-4 mt-4">
-                {reportData.contract_checklist.map((item, idx) => (
+                {reportData.contract_checklist.map((item, idx) => {
+                  const relatedClauses = item.basis?.filter(b => b.includes("특약")) ?? [];
+                  return (
                   <details key={idx} className="group/check bg-gray-50 border border-gray-100 rounded-lg">
-                    <summary className="flex items-center gap-2 p-4 cursor-pointer list-none [&::-webkit-details-marker]:hidden select-none outline-none">
-                      <span className="flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-sm font-bold flex-shrink-0">{idx + 1}</span>
-                      <h4 className="text-base font-semibold text-gray-900">{item.item}</h4>
-                      <ChevronDown className="w-4 h-4 text-gray-400 transition-transform rotate-180 group-open/check:rotate-0 ml-auto flex-shrink-0" />
+                    <summary className="flex items-start gap-2 p-4 cursor-pointer list-none [&::-webkit-details-marker]:hidden select-none outline-none">
+                      <span className="flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-sm font-bold flex-shrink-0 mt-0.5">{idx + 1}</span>
+                      <div className="flex flex-col gap-1.5 flex-1 min-w-0">
+                        <h4 className="text-base font-semibold text-gray-900">{item.item}</h4>
+                        {relatedClauses.length > 0 && (
+                          <div className="flex flex-wrap gap-1.5">
+                            {relatedClauses.map((c, cIdx) => (
+                              <span key={cIdx} className="text-[11px] bg-blue-50 text-blue-700 border border-blue-200 px-2 py-0.5 rounded-full font-medium">{c}</span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <ChevronDown className="w-4 h-4 text-gray-400 transition-transform rotate-180 group-open/check:rotate-0 flex-shrink-0 mt-1" />
                     </summary>
                     <div className="p-4 pt-0">
-                      <p className="text-sm text-gray-700 leading-relaxed ml-8">{item.description}</p>
+                      <div className="ml-8 prose prose-sm max-w-none text-gray-700 prose-li:my-0.5 prose-ul:my-1 prose-p:my-1 [&_strong]:text-gray-900">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.description ?? ""}</ReactMarkdown>
+                      </div>
                       {item.basis && item.basis.length > 0 && (() => {
                       const laws: string[] = [];
                       const precs: string[] = [];
                       const clauses: string[] = [];
-                      
+
                       item.basis.forEach(b => {
                         if (b.includes("특약")) {
                           clauses.push(b);
@@ -410,13 +646,6 @@ export default function AnalysisPage() {
 
                       return (
                         <div className="ml-8 mt-3 flex flex-col gap-3">
-                          {clauses.length > 0 && (
-                            <div className="flex flex-wrap gap-2">
-                              {clauses.map((c, cIdx) => (
-                                <span key={`c-${cIdx}`} className="text-xs bg-gray-200 text-gray-700 px-2 py-1 rounded-md font-medium">{c}</span>
-                              ))}
-                            </div>
-                          )}
                           
                           {laws.length > 0 && (
                             <details className="group border border-gray-200 rounded-lg overflow-hidden">
@@ -454,11 +683,23 @@ export default function AnalysisPage() {
                     })()}
                     </div>
                   </details>
-                ))}
+                  );
+                })}
               </div>
             </details>
           )}
 
+          {reportStatus === "idle" && (
+            <div className="flex items-center justify-center h-64 text-gray-400 border border-dashed rounded-xl text-sm">
+              특약 분석이 완료되면 체크리스트가 생성됩니다.
+            </div>
+          )}
+            </>
+          )}
+
+          {/* 특약 분석 탭 */}
+          {viewTab === "analysis" && (
+            <>
           {/* 개별 특약 렌더링 */}
           {specialTerms.length > 0 && (
             <details className="group flex flex-col p-6 rounded-xl border bg-white shadow-sm border-blue-200" open>
@@ -497,12 +738,25 @@ export default function AnalysisPage() {
                     return `[${ref}]`;
                   };
 
+                  const hasViolation = clauseResults[idx]?.llmRelatedLaws?.some((l: RelatedLaw) => l.is_violation) ?? false;
+                  const hasPrecedent = clauseResults[idx]?.llmRelatedLaws?.some((l: RelatedLaw) => l.type === "판례") ?? false;
+                  const isDone = clauseResults[idx]?.status === "done";
+
+                  const borderCls = !isDone
+                    ? "border-gray-200 border-l-gray-300"
+                    : hasViolation
+                    ? "border-gray-200 border-l-rose-400"
+                    : hasPrecedent
+                    ? "border-gray-200 border-l-amber-400"
+                    : "border-gray-200 border-l-emerald-400";
+
                   return (
-                    <div 
-                      key={idx} 
+                    <div
+                      key={idx}
                       id={`analysis-result-${idx}`}
-                      className="rounded-xl border bg-gray-50/30 scroll-mt-4 overflow-hidden"
-                      style={{ borderColor: "#E2E8F0" }}
+                      className={`rounded-xl border border-l-[5px] bg-gray-50/30 scroll-mt-4 overflow-hidden ${borderCls}`}
+                      onMouseEnter={() => setActiveClauseIdx(idx)}
+                      onMouseLeave={() => setActiveClauseIdx(null)}
                     >
                       <details className="group/item">
                         <summary className="flex items-start justify-between gap-4 p-5 cursor-pointer list-none [&::-webkit-details-marker]:hidden select-none outline-none hover:bg-gray-50 transition-colors">
@@ -531,124 +785,261 @@ export default function AnalysisPage() {
 
                         <div className="p-5 pt-2 border-t border-gray-100 flex flex-col gap-6">
 
-                  {/* LLM 요약 (Phase 1 완료 시 즉시 노출) */}
-                  {clauseResults[idx]?.status === "done" && (
-                    <div className="flex flex-col gap-3">
-                      {llmLaws.length > 0 && (
-                        <details className="group/laws border border-blue-200 rounded-lg overflow-hidden">
-                          <summary className="flex items-center justify-between text-sm font-semibold text-blue-900 bg-blue-50 px-4 py-3 cursor-pointer hover:bg-blue-100 select-none list-none">
-                            <span>관련된 법령</span>
-                            <ChevronDown className="w-4 h-4 text-blue-400 transition-transform rotate-180 group-open/laws:rotate-0" />
-                          </summary>
-                          <div className="flex flex-col gap-4 p-4 bg-white border-t border-blue-100">
-                            {llmLaws.map((law, lIdx) => (
-                              law.summary && (
-                                <div key={`law-sum-${lIdx}`} className="text-sm text-gray-700 leading-relaxed">
-                                  <strong className={`flex items-center gap-2 mb-2 ${law.is_violation ? 'text-red-600' : 'text-gray-900'}`}>
-                                    [{law.ref.replace(/_/g, ' ')}]
-                                    {law.is_violation && (
-                                      <span className="px-1.5 py-0.5 rounded bg-red-600 text-[10px] font-black text-white uppercase tracking-tighter">
-                                        주의
-                                      </span>
-                                    )}
-                                  </strong>
-                                  {law.content && (
-                                    <details className="group/raw-law mt-3 p-3 bg-gray-50 border border-gray-100 rounded-lg">
-                                      <summary className="flex items-center justify-between text-xs font-semibold text-gray-700 cursor-pointer select-none list-none">
-                                        <span>원문 보기</span>
-                                        <ChevronDown className="w-3 h-3 text-gray-400 transition-transform rotate-180 group-open/raw-law:rotate-0" />
-                                      </summary>
-                                      <p className="mt-2 text-xs whitespace-pre-wrap text-gray-600">
-                                        {law.content}
-                                      </p>
-                                    </details>
-                                  )}
-                                  {law.is_violation ? (
-                                    <div className="mt-3 p-4 bg-red-50 border border-red-100 rounded-lg flex flex-col gap-2">
-                                      <div className="flex items-center gap-2 text-red-600 font-bold text-xs">
-                                        <AlertCircle className="w-4 h-4" />
-                                        <span>주의 사항 및 이유</span>
-                                      </div>
-                                      <p className="whitespace-pre-wrap text-red-900 font-medium">{law.summary}</p>
+                  {/* 분석 결과 (Phase 1 완료 시 즉시 노출) */}
+                  {clauseResults[idx]?.status === "done" && (() => {
+                    const anyViolation = llmRelatedLaws.some((l: RelatedLaw) => l.is_violation);
+
+                    return (
+                      <div className="flex flex-col gap-4">
+
+                        {/* ① 분석 불릿 섹션 */}
+                        <div className="flex flex-col gap-3 p-4 rounded-lg border border-blue-200 bg-blue-50/60">
+                          <ul className="flex flex-col gap-3 text-sm leading-relaxed">
+
+                            {/* 한 줄 요약 */}
+                            <li className="flex items-start gap-2">
+                              <span className="text-blue-500 font-bold shrink-0 mt-0.5">•</span>
+                              <div>
+                                <strong className="text-gray-900">한 줄 해석: </strong>
+                                {clauseResults[idx]?.clauseOneLineSummary
+                                  ? <span className="text-gray-700">{clauseResults[idx].clauseOneLineSummary}</span>
+                                  : <span className="text-gray-400 italic">해석 정보 없음</span>
+                                }
+                              </div>
+                            </li>
+
+                            {/* 특약 해석 */}
+                            <li className="flex items-start gap-2">
+                              <span className="text-blue-500 font-bold shrink-0 mt-0.5">•</span>
+                              <div className="flex-1">
+                                {clauseResults[idx]?.clauseInterpretation ? (
+                                  <details className="group/interp">
+                                    <summary className="flex items-center gap-1 cursor-pointer select-none list-none w-fit text-gray-900 hover:text-gray-800 transition-colors">
+                                      <span className="text-sm font-medium">특약 해석 자세히 보기</span>
+                                      <ChevronDown className="w-3.5 h-3.5 transition-transform group-open/interp:rotate-180" />
+                                    </summary>
+                                    <div className="mt-2 prose prose-sm max-w-none text-gray-700 prose-li:my-0.5 prose-ul:my-1 prose-p:my-1 [&_strong]:text-gray-900">
+                                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{clauseResults[idx].clauseInterpretation!}</ReactMarkdown>
                                     </div>
+                                  </details>
+                                ) : (
+                                  <><strong className="text-gray-900">특약 해석: </strong><span className="text-gray-400 italic">해석 정보 없음</span></>
+                                )}
+                              </div>
+                            </li>
+
+                            {/* 주의 사항 */}
+                            <li className="flex items-start gap-2">
+                              <span className={`font-bold shrink-0 mt-0.5 ${anyViolation ? 'text-red-500' : 'text-blue-500'}`}>•</span>
+                              <div className="flex flex-col gap-2 flex-1">
+                                <div>
+                                  <strong className="text-gray-900">주의 사항: </strong>
+                                  {anyViolation ? (
+                                    <span className="text-red-600 font-semibold">⚠️ 법령 위배 가능성</span>
                                   ) : (
-                                    <p className="whitespace-pre-wrap mt-2">{law.summary}</p>
+                                    <span className="text-green-700">특이 사항 없음</span>
                                   )}
                                 </div>
-                              )
-                            ))}
-                          </div>
-                        </details>
-                      )}
+                                {anyViolation && (() => {
+                                  const violationItems = [...llmLaws, ...llmPrecs].filter((l: any) => l.is_violation && l.summary);
+                                  return (
+                                    <>
+                                      {violationItems.map((law: any, vIdx: number) => {
+                                        const parts = law.summary.split(/\n\n+/);
+                                        const shortSummary = parts[0]?.trim() ?? "";
+                                        const detailedContent = parts.slice(1).join("\n\n").trim();
+                                        const isPrec = law.type === "판례";
+                                        const refLabel = isPrec ? formatPrecTitle(law.ref) : law.ref.replace(/_/g, ' ');
+                                        return (
+                                          <div key={`alert-${vIdx}`} className="rounded-lg border border-red-200 bg-red-50 overflow-hidden">
+                                            <div className="flex items-center gap-2 px-3 pt-3 pb-1">
+                                              <span className="text-base">⚠️</span>
+                                              <span className="text-sm font-bold text-red-700">
+                                                {refLabel} 위반 가능성
+                                              </span>
+                                              <span className="ml-auto text-[10px] font-black px-1.5 py-0.5 rounded bg-red-200 text-red-700">위반</span>
+                                            </div>
+                                            {shortSummary && (
+                                              <p className="text-xs text-red-800 px-3 pb-2 leading-relaxed">{shortSummary}</p>
+                                            )}
+                                            {detailedContent && (
+                                              <details className="group/detail">
+                                                <summary className="flex items-center justify-between px-3 py-2 text-xs font-semibold text-red-600 hover:bg-red-100 cursor-pointer select-none list-none border-t border-red-100">
+                                                  <span>자세히 보기</span>
+                                                  <ChevronDown className="w-3 h-3 transition-transform rotate-180 group-open/detail:rotate-0" />
+                                                </summary>
+                                                <div className="px-3 pb-3 pt-2 prose prose-xs max-w-none prose-li:my-0.5 prose-ul:my-1 border-t border-red-100 text-red-900 [&_strong]:text-red-800">
+                                                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{detailedContent}</ReactMarkdown>
+                                                </div>
+                                              </details>
+                                            )}
+                                          </div>
+                                        );
+                                      })}
+                                      {/* 특약 재작성 버튼 */}
+                                      <button
+                                        onClick={() => handleRewriteClause(
+                                          idx,
+                                          specialTerms[idx],
+                                          violationItems,
+                                          llmRelatedLaws,
+                                        )}
+                                        className="w-full mt-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-red-300 bg-white hover:bg-red-50 text-red-700 text-xs font-semibold transition-colors"
+                                      >
+                                        ✏️ 법령에 맞게 특약 재작성하기
+                                      </button>
+                                    </>
+                                  );
+                                })()}
+                              </div>
+                            </li>
 
-                      {llmPrecs.length > 0 && (
-                        <details className="group/precs border border-green-200 rounded-lg overflow-hidden">
-                          <summary className="flex items-center justify-between text-sm font-semibold text-green-900 bg-green-50 px-4 py-3 cursor-pointer hover:bg-green-100 select-none list-none">
-                            <span>유사한 분쟁 사례</span>
-                            <ChevronDown className="w-4 h-4 text-green-400 transition-transform rotate-180 group-open/precs:rotate-0" />
-                          </summary>
-                          <div className="flex flex-col gap-4 p-4 bg-white border-t border-green-100">
-                            {llmPrecs.map((prec, pIdx) => (
-                              prec.summary && (
-                                <div key={`prec-sum-${pIdx}`} className="text-sm text-gray-700 leading-relaxed">
-                                  <strong className={`flex items-center gap-2 mb-2 ${prec.is_violation ? 'text-red-600' : 'text-gray-900'}`}>
+                          </ul>
+                        </div>
+
+                        {/* ① 다른 특약과 연관성 */}
+                        {reportStatus === "loading" && (
+                          <div className="flex flex-col gap-2">
+                            <p className="text-xs font-semibold text-gray-500 px-1">다른 특약과 연관성</p>
+                            <div className="flex items-center gap-2 px-1 text-xs text-gray-400">
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                              <span>연관 특약 분석 중...</span>
+                            </div>
+                          </div>
+                        )}
+                        {reportStatus === "done" && llmRelatedClauses.length > 0 && (
+                          <div className="flex flex-col gap-2">
+                            <p className="text-xs font-semibold text-gray-500 px-1">다른 특약과 연관성</p>
+                            <div className="flex flex-wrap gap-1.5">
+                              {llmRelatedClauses.map((rel, rIdx) => {
+                                const key = `${idx}-rel-${rIdx}`;
+                                const isOpen = openPopover === key;
+                                return (
+                                  <button
+                                    key={key}
+                                    onClick={() => setOpenPopover(isOpen ? null : key)}
+                                    className={`text-xs px-2.5 py-1 rounded-full border font-medium transition-colors ${
+                                      isOpen
+                                        ? "border-orange-400 bg-orange-100 text-orange-800"
+                                        : "border-orange-200 bg-orange-50 text-orange-700 hover:bg-orange-100"
+                                    }`}
+                                  >
+                                    {rel.clause_id}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                            {/* 말풍선 팝오버 */}
+                            {llmRelatedClauses.map((rel, rIdx) => {
+                              const key = `${idx}-rel-${rIdx}`;
+                              if (openPopover !== key) return null;
+                              return (
+                                <div key={`pop-${key}`} className="relative mt-1">
+                                  <div className="absolute left-4 -top-2 w-3 h-3 rotate-45 border-t border-l border-gray-200 bg-white z-10" />
+                                  <div className="relative z-20 rounded-xl border border-gray-200 bg-white shadow-lg p-4 flex flex-col gap-2">
+                                    {rel.clause_text && (
+                                      <p className="text-xs text-gray-500 leading-relaxed border-b border-gray-100 pb-2">
+                                        &ldquo;{rel.clause_text}&rdquo;
+                                      </p>
+                                    )}
+                                    <p className="text-sm text-gray-700 leading-relaxed">{rel.relation}</p>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+
+                        {/* ② 관련 법령 */}
+                        {llmLaws.length > 0 && (
+                          <div className="flex flex-col gap-2">
+                            <p className="text-xs font-semibold text-gray-500 px-1">관련 법령</p>
+                            <div className="flex flex-wrap gap-1.5">
+                              {llmLaws.map((law, lIdx) => {
+                                const key = `${idx}-law-${lIdx}`;
+                                const isOpen = openPopover === key;
+                                return (
+                                  <button
+                                    key={key}
+                                    onClick={() => setOpenPopover(isOpen ? null : key)}
+                                    className={`text-xs px-2.5 py-1 rounded-full border font-medium transition-colors ${
+                                      law.is_violation
+                                        ? "border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
+                                        : isOpen
+                                        ? "border-blue-400 bg-blue-100 text-blue-800"
+                                        : "border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100"
+                                    }`}
+                                  >
+                                    {law.ref.replace(/_/g, ' ')}
+                                    {law.is_violation && <span className="ml-1 text-red-500">⚠️</span>}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                            {/* 말풍선 팝오버 */}
+                            {llmLaws.map((law, lIdx) => {
+                              const key = `${idx}-law-${lIdx}`;
+                              if (openPopover !== key) return null;
+                              return (
+                                <div key={`pop-${key}`} className="relative mt-1">
+                                  <div className="absolute left-4 -top-2 w-3 h-3 rotate-45 border-t border-l border-gray-200 bg-white z-10" />
+                                  <div className="relative z-20 rounded-xl border border-gray-200 bg-white shadow-lg p-4 text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">
+                                    {law.content || "원문 정보 없음"}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+
+                        {/* ③ 유사한 분쟁 사례 */}
+                        {llmPrecs.length > 0 && (
+                          <div className="flex flex-col gap-2">
+                            <p className="text-xs font-semibold text-gray-500 px-1">유사한 분쟁 사례</p>
+                            <div className="flex flex-wrap gap-1.5">
+                              {llmPrecs.map((prec, pIdx) => {
+                                const key = `${idx}-prec-${pIdx}`;
+                                const isOpen = openPopover === key;
+                                return (
+                                  <button
+                                    key={key}
+                                    onClick={() => setOpenPopover(isOpen ? null : key)}
+                                    className={`text-xs px-2.5 py-1 rounded-full border font-medium transition-colors ${
+                                      prec.is_violation
+                                        ? "border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
+                                        : isOpen
+                                        ? "border-green-500 bg-green-100 text-green-800"
+                                        : "border-green-200 bg-green-50 text-green-700 hover:bg-green-100"
+                                    }`}
+                                  >
                                     {formatPrecTitle(prec.ref)}
-                                    {prec.is_violation && (
-                                      <span className="px-1.5 py-0.5 rounded bg-red-600 text-[10px] font-black text-white uppercase tracking-tighter">
-                                        주의
-                                      </span>
-                                    )}
-                                  </strong>
-                                  {prec.content && (
-                                    <details className="group/raw-prec mt-3 p-3 bg-gray-50 border border-gray-100 rounded-lg">
-                                      <summary className="flex items-center justify-between text-xs font-semibold text-gray-700 cursor-pointer select-none list-none">
-                                        <span>판결 요지 보기</span>
-                                        <ChevronDown className="w-3 h-3 text-gray-400 transition-transform rotate-180 group-open/raw-prec:rotate-0" />
-                                      </summary>
-                                      <p className="mt-2 text-xs whitespace-pre-wrap text-gray-600">
-                                        {prec.content}
-                                      </p>
-                                    </details>
-                                  )}
-                                  {prec.is_violation ? (
-                                    <div className="mt-3 p-4 bg-red-50 border border-red-100 rounded-lg flex flex-col gap-2">
-                                      <div className="flex items-center gap-2 text-red-600 font-bold text-xs">
-                                        <AlertCircle className="w-4 h-4" />
-                                        <span>주의 사항 및 이유</span>
-                                      </div>
-                                      <p className="whitespace-pre-wrap text-red-900 font-medium">{prec.summary}</p>
-                                    </div>
-                                  ) : (
-                                    <p className="whitespace-pre-wrap mt-2">{prec.summary}</p>
-                                  )}
+                                    {prec.is_violation && <span className="ml-1 text-red-500">⚠️</span>}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                            {/* 말풍선 팝오버 */}
+                            {llmPrecs.map((prec, pIdx) => {
+                              const key = `${idx}-prec-${pIdx}`;
+                              if (openPopover !== key) return null;
+                              return (
+                                <div key={`pop-${key}`} className="relative mt-1">
+                                  <div className="absolute left-4 -top-2 w-3 h-3 rotate-45 border-t border-l border-gray-200 bg-white z-10" />
+                                  <div className="relative z-20 rounded-xl border border-gray-200 bg-white shadow-lg p-4">
+                                    {prec.summary
+                                      ? <div className="prose prose-sm max-w-none text-gray-700 prose-li:my-0.5 prose-ul:my-1 prose-p:my-0.5 [&_strong]:text-gray-900"><ReactMarkdown remarkPlugins={[remarkGfm]}>{prec.summary}</ReactMarkdown></div>
+                                      : <p className="text-sm text-gray-400">내용 없음</p>
+                                    }
+                                  </div>
                                 </div>
-                              )
-                            ))}
+                              );
+                            })}
                           </div>
-                        </details>
-                      )}
+                        )}
 
-                      {/* 연관성 주의 (Phase 2 완료 후 노출) */}
-                      {reportStatus === "done" && llmRelatedClauses.length > 0 && (
-                        <details className="group/rel border border-orange-200 rounded-lg overflow-hidden">
-                          <summary className="flex items-center justify-between text-sm font-semibold text-orange-900 bg-orange-50 px-4 py-3 cursor-pointer hover:bg-orange-100 select-none list-none">
-                            <span>함께 확인해야 할 특약</span>
-                            <ChevronDown className="w-4 h-4 text-orange-400 transition-transform rotate-180 group-open/rel:rotate-0" />
-                          </summary>
-                          <div className="flex flex-col gap-4 p-4 bg-white border-t border-orange-100">
-                            <ul className="list-disc pl-5 space-y-4 text-sm text-gray-700 leading-relaxed">
-                              {llmRelatedClauses.map((rel, rIdx) => (
-                                <li key={`rel-${rIdx}`}>
-                                  <strong className="block text-gray-900 mb-2">[{rel.clause_id}] "{rel.clause_text}"</strong>
-                                  <p className="whitespace-pre-wrap">{rel.relation}</p>
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                        </details>
-                      )}
-                    </div>
-                  )}
+                      </div>
+                    );
+                  })()}
 
                   {/* 분석 결과 (로딩 완료 시에만) - 관련 법령/판례 20개 표시 부분 제거 요청으로 주석 처리
                   {clauseResults[idx]?.status !== "loading" && (
@@ -679,22 +1070,61 @@ export default function AnalysisPage() {
               분석할 특약사항이 없습니다.
             </div>
           )}
+            </>
+          )}
+          </div>{/* end scrollable content */}
         </section>
+
+      {/* 체크리스트 완료 말풍선 — position:fixed로 overflow 클리핑 완전 우회 */}
+      {showChecklistToast && toastPos && !rewriteModal && (
+        <div
+          className="fixed z-[9999] whitespace-nowrap"
+          style={{
+            left: toastPos.left,
+            top: toastPos.top - 8,
+            transform: "translate(-50%, -100%)",
+          }}
+        >
+          <div
+            className="flex items-center gap-2 px-3 py-2 rounded-xl bg-white border border-green-200 shadow-lg text-sm text-green-800 font-medium cursor-pointer hover:bg-green-50 transition-colors"
+            onClick={() => { setShowChecklistToast(false); setViewTab("checklist"); }}
+          >
+            <span>✅</span>
+            <span>체크리스트 작성 완료!</span>
+            <button
+              onClick={(e) => { e.stopPropagation(); setShowChecklistToast(false); }}
+              className="ml-0.5 text-green-400 hover:text-green-700 transition-colors font-bold leading-none"
+              aria-label="닫기"
+            >
+              ×
+            </button>
+          </div>
+          {/* 아래쪽 화살표 */}
+          <div className="absolute left-1/2 -translate-x-1/2 -bottom-[5px] w-2.5 h-2.5 rotate-45 border-b border-r border-green-200 bg-white z-10" />
+        </div>
+      )}
       </div>
 
       {/* <BottomActionBar onChatbot={() => setIsChatOpen(true)} /> */}
       
       {/* 챗봇 컴포넌트 */}
-      <ChatBot 
+      <ChatBot
         isOpen={isChatOpen}
         onOpen={() => setIsChatOpen(true)}
         onClose={() => setIsChatOpen(false)}
+        showNudge={analysisStatus === "done" && !isChatOpen}
         context={{
           report: reportData,
           clauses: Object.values(clauseResults).map(res => ({
             laws: res.llmRelatedLaws,
             status: res.status
           })),
+          rewrittenClauses: Object.entries(rewriteCache).reduce<Record<string, { rewrittenClause: string; reason: string }>>((acc, [idxStr, val]) => {
+            const idx = Number(idxStr);
+            const displayIdx = idx - 6 + 1; // 특약 N (공통특약 제외)
+            acc[`특약${displayIdx}`] = val;
+            return acc;
+          }, {}),
           rawContract: typeof window !== "undefined" ? JSON.parse(sessionStorage.getItem("ade.analysis.contract") || "{}") : null
         }}
       />

--- a/frontend/components/analysis/ChatBot.tsx
+++ b/frontend/components/analysis/ChatBot.tsx
@@ -15,16 +15,19 @@ type ChatBotProps = {
   isOpen: boolean;
   onOpen: () => void;
   onClose: () => void;
+  showNudge?: boolean;
   context: {
     report: any;
     clauses: any;
+    rewrittenClauses?: Record<string, { rewrittenClause: string; reason: string }>;
     rawContract?: any;
   };
 };
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
 
-export function ChatBot({ isOpen, onOpen, onClose, context }: ChatBotProps) {
+export function ChatBot({ isOpen, onOpen, onClose, showNudge = false, context }: ChatBotProps) {
+  const [nudgeDismissed, setNudgeDismissed] = useState(false);
   const [messages, setMessages] = useState<Message[]>([
     {
       role: "assistant",
@@ -92,12 +95,31 @@ export function ChatBot({ isOpen, onOpen, onClose, context }: ChatBotProps) {
     <>
       {/* Floating FAB Button */}
       {!isOpen && (
-        <button
-          onClick={onOpen}
-          className="fixed bottom-8 right-8 z-50 flex items-center justify-center w-14 h-14 bg-[#002045] text-white rounded-full shadow-2xl hover:bg-[#003366] transition-all transform hover:scale-110"
-        >
-          <MessageCircle className="w-7 h-7" />
-        </button>
+        <div className="fixed bottom-8 right-8 z-50 flex flex-col items-center gap-2">
+          {/* 유도 말풍선 */}
+          {showNudge && !nudgeDismissed && (
+            <div className="relative whitespace-nowrap">
+              <div className="flex items-center gap-2 pl-3 pr-2 py-2 rounded-xl bg-[#002045] text-white text-xs font-medium shadow-lg">
+                <span>추가적으로 궁금한 점을 물어보세요!</span>
+                <button
+                  onClick={(e) => { e.stopPropagation(); setNudgeDismissed(true); }}
+                  className="text-white/60 hover:text-white transition-colors leading-none font-bold text-sm"
+                  aria-label="닫기"
+                >
+                  ×
+                </button>
+              </div>
+              {/* 아래 화살표 */}
+              <div className="absolute left-1/2 -translate-x-1/2 -bottom-[5px] w-2.5 h-2.5 rotate-45 bg-[#002045] z-10" />
+            </div>
+          )}
+          <button
+            onClick={onOpen}
+            className="flex items-center justify-center w-14 h-14 bg-[#002045] text-white rounded-full shadow-2xl hover:bg-[#003366] transition-all transform hover:scale-110"
+          >
+            <MessageCircle className="w-7 h-7" />
+          </button>
+        </div>
       )}
 
       {/* Chat Window */}
@@ -107,7 +129,7 @@ export function ChatBot({ isOpen, onOpen, onClose, context }: ChatBotProps) {
           <div className="flex items-center justify-between px-5 py-4 bg-[#002045] text-white">
             <div className="flex items-center gap-2">
               <Bot className="w-5 h-5" />
-              <span className="font-bold text-lg">ADE AI 챗봇</span>
+              <span className="font-bold text-lg">CLARA 챗봇</span>
             </div>
             <button
               onClick={onClose}

--- a/frontend/components/analysis/DocumentPanel.tsx
+++ b/frontend/components/analysis/DocumentPanel.tsx
@@ -13,13 +13,15 @@ type DocumentPanelProps = {
   specialTerms: string[];
   generalTerms: GeneralTerm[];
   onTermClick?: (index: number) => void;
+  activeIdx?: number | null;
 };
 
-export function DocumentPanel({ 
-  contractTitle, 
-  specialTerms, 
+export function DocumentPanel({
+  contractTitle,
+  specialTerms,
   generalTerms,
-  onTermClick 
+  onTermClick,
+  activeIdx,
 }: DocumentPanelProps) {
 
   // Simple pre-processor for messy table syntax
@@ -116,19 +118,24 @@ export function DocumentPanel({
         {/* 1. 분석 대상 특약 사항 */}
         {specialTerms.length > 0 && (
           <div className="flex flex-col gap-4">
-            <h3 className="px-2 text-sm font-black text-blue-700 uppercase tracking-widest border-l-4 border-blue-600">
+            <h3 className="px-2 text-base font-black text-blue-700 uppercase tracking-widest border-l-4 border-blue-600">
               특약 사항
             </h3>
             <div className="flex flex-col gap-2">
               {specialTerms.slice(6).map((text, i) => {
                 const absoluteIndex = i + 6;
+                const isActive = activeIdx === absoluteIndex;
                 return (
                   <button
                     key={`target-${i}`}
                     onClick={() => onTermClick?.(absoluteIndex)}
-                    className="group flex flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4 text-left transition hover:border-blue-300 hover:bg-blue-50 hover:shadow-sm"
+                    className={`group flex flex-col gap-1 rounded-lg border p-4 text-left transition hover:border-blue-300 hover:bg-blue-50 hover:shadow-sm ${
+                      isActive
+                        ? "border-blue-400 bg-blue-50 shadow-sm ring-2 ring-blue-200"
+                        : "border-gray-200 bg-white"
+                    }`}
                   >
-                    <span className="text-[10px] font-bold text-gray-400 uppercase group-hover:text-blue-500">
+                    <span className={`text-xs font-bold uppercase ${isActive ? "text-blue-600" : "text-gray-400 group-hover:text-blue-500"}`}>
                       특약 {i + 1}
                     </span>
                     <div className="text-sm text-gray-800 leading-relaxed font-medium">
@@ -152,7 +159,7 @@ export function DocumentPanel({
         {/* 2. 공통 특약 */}
         {specialTerms.length >= 6 && (
           <div className="flex flex-col gap-4">
-            <h3 className="px-2 text-sm font-black text-blue-700 uppercase tracking-widest border-l-4 border-blue-600">
+            <h3 className="px-2 text-base font-black text-blue-700 uppercase tracking-widest border-l-4 border-blue-600">
               공통 특약
             </h3>
             <div className="flex flex-col gap-2">
@@ -161,7 +168,7 @@ export function DocumentPanel({
                   key={`common-${i}`}
                   className="flex flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4 text-left"
                 >
-                  <span className="text-[10px] font-bold text-gray-400 uppercase">
+                  <span className="text-xs font-bold text-gray-400 uppercase">
                     공통특약 {i + 1}
                   </span>
                   <div className="text-sm text-gray-800 leading-relaxed font-medium">
@@ -184,13 +191,13 @@ export function DocumentPanel({
         {/* 3. 일반 조항 섹션 */}
         {generalTerms.length > 0 && (
           <div className="flex flex-col gap-4">
-            <h3 className="px-2 text-sm font-black text-blue-700 uppercase tracking-widest border-l-4 border-blue-600">
+            <h3 className="px-2 text-base font-black text-blue-700 uppercase tracking-widest border-l-4 border-blue-600">
               일반 조항
             </h3>
             <div className="flex flex-col gap-4">
               {generalTerms.map((term, i) => (
                 <div key={i} className="flex flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4 text-left">
-                  <span className="text-[10px] font-bold text-gray-400 uppercase">{term.title}</span>
+                  <span className="text-xs font-bold text-gray-400 uppercase">{term.title}</span>
                   <div className="text-sm text-gray-800 leading-relaxed font-medium">
                     <ReactMarkdown 
                       remarkPlugins={[remarkGfm]}

--- a/pipeline/generation/report_generator_v2.py
+++ b/pipeline/generation/report_generator_v2.py
@@ -29,9 +29,28 @@ class SelectedLaw(BaseModel):
     ref: str | None = None
     summary: str | None = None
     is_violation: bool = False
+    is_caution: bool = False
+
+    @field_validator("is_violation", "is_caution", mode="before")
+    @classmethod
+    def coerce_bool(cls, v):
+        if isinstance(v, str):
+            return v.strip().lower() in ("true", "1", "yes")
+        return bool(v) if v is not None else False
 
 class ClauseSummaryOutput(BaseModel):
+    clause_one_line_summary: str = ""
+    clause_interpretation: str = ""
     selected_laws: list[SelectedLaw] = []
+
+    @field_validator("clause_one_line_summary", "clause_interpretation", mode="before")
+    @classmethod
+    def coerce_str(cls, v):
+        if v is None:
+            return ""
+        if isinstance(v, list):
+            return "\n".join(f"• {item.lstrip('•- ').strip()}" for item in v if item)
+        return str(v)
 
     @field_validator("selected_laws", mode="before")
     @classmethod
@@ -130,11 +149,14 @@ def build_clause_summary_prompt(
     all_doc_ids = [m.get("doc_id", "") for m in laws + precs if m.get("doc_id")]
     output_format = json.dumps(
         {
+            "clause_one_line_summary": "이 특약은 ... 한다는 내용입니다. (20자 내외 한 문장)",
+            "clause_interpretation": "- 이 특약의 핵심 의미는 ...\n- 임차인 입장에서 주의할 점은 ...\n- 관련 법령에 따르면 ...",
             "selected_laws": [
                 {
-                    "ref": "<위 목록의 doc_id 그대로>", 
-                    "summary": "<일반인이 이해할 수 있는 설명>",
-                    "is_violation": "<true/false>"
+                    "ref": "<위 목록의 doc_id 그대로>",
+                    "summary": "<is_violation 또는 is_caution이 true면 첫 줄 한 문장 요약 + 빈 줄 + 마크다운 상세 설명 / 둘 다 false면 빈 문자열>",
+                    "is_violation": False,
+                    "is_caution": False
                 }
             ]
         },
@@ -155,27 +177,57 @@ def build_clause_summary_prompt(
 [출력 지시]
 위 분석 대상 특약을 검토하여 아래 JSON 형식으로만 응답하세요.
 
-- selected_laws: [관련 법령]과 [관련 판례] 중 반드시 이 특약과 **직접적으로 관련 있는 상위 3개 이내의 항목**만 골라 연관도 높은 순서로 작성하세요.
-  *   **주의**: 제공된 리스트에 없는 법령 번호나 판례를 외부 지식으로 생성하여 포함하지 마세요. 반드시 대괄호 안의 식별자({', '.join(all_doc_ids)})만 사용해야 합니다.
-  *   **주의**: 연관성이 낮거나 단순히 용어가 겹치는 정도의 항목은 과감하게 제외하세요. 정말로 관련 있는 항목이 없으면 빈 배열([])을 반환하세요.
-  
-  is_violation 판단 기준:
-    · 특약 내용이 해당 법령의 **강행규정(임차인에게 불리한 약정은 효력이 없다는 규정 등)**에 명백히 위배되는 경우 `true`로 설정하세요.
-    · 판례상 임차인의 권리를 부당하게 제한한다고 판단된 사례와 유사한 경우 `true`로 설정하세요.
-    · 단순히 절차 안내이거나 상호 합의 가능한 범위 내의 사항이면 `false`로 설정하세요.
+- clause_one_line_summary: 이 특약 전체를 **한 문장**으로 요약하세요.
+  · 법률 지식이 없는 일반인이 바로 이해할 수 있도록 쉽고 간결하게 작성하세요.
+  · 20자 내외, 마침표로 끝내세요. 마크다운 기호는 사용하지 마세요.
+  · 예시: "임차인이 먼저 퇴실하면 남은 기간 임대료를 부담해야 합니다."
+
+- clause_interpretation: 이 특약이 의미하는 바를 법률 지식이 없는 일반인도 이해할 수 있도록 쉬운 말로 바꿔 설명하세요.
+  · 반드시 제공된 [관련 법령]·[관련 판례]를 근거로 설명하세요. 외부 지식을 사용하지 마세요.
+  · 어떤 상황에서 어떤 권리가 보호되거나 제한될 수 있는지, 임차인이 실제로 알아야 할 핵심만 담으세요.
+  · **말투는 "~했음.", "~임.", "~가능함." 형식의 개조식**으로 작성하세요. "~합니다", "~세요", "~해요" 형식은 사용하지 마세요.
+  · **법률 전문 용어는 반드시 괄호 안에 풀어쓰세요.** 예) 묵시적 갱신(계약 만료 후 아무 말 없이 자동으로 계약이 연장되는 것), 중개보수(부동산 중개업소에 내는 수수료), 대항력(집이 팔려도 계속 살 수 있는 권리), 보증금반환청구권(계약 끝날 때 맡긴 돈을 돌려달라고 요구할 수 있는 권리)
+  · 특약 원문을 그대로 반복하지 마세요.
+  · **마크다운 형식**으로 작성하세요. `#`, `##` 등 제목 기호는 절대 사용하지 마세요.
+  · `- ` 불릿 포인트로 2~4개 항목을 작성하세요.
+  · **불릿 하나에 반드시 한 문장만** 작성하세요. 두 문장 이상이면 별도 불릿으로 분리하세요.
+    형식 예시:
+    - 이 특약의 핵심 의미는 ...입니다.
+    - 묵시적 갱신(계약 만료 후 아무 말 없이 자동으로 연장되는 것)이 되면 ...할 수 있습니다.
+    - 관련 법령에 따르면 ...
+
+- selected_laws: [관련 법령]과 [관련 판례] 중 이 특약과 **직접적으로 관련 있는 상위 3개 이내**만 골라 작성하세요.
+  *   **주의**: 제공된 리스트에 없는 항목을 외부 지식으로 생성하지 마세요. 반드시 식별자({', '.join(all_doc_ids)})만 사용하세요.
+  *   **주의**: 연관성이 낮거나 단순히 용어가 겹치는 항목은 제외하세요. 정말 관련 있는 항목이 없으면 빈 배열([])을 반환하세요.
+
+  is_violation / is_caution 판단 기준 (반드시 제공된 법령·판례 내용만 근거로 판단하세요):
+    · **is_violation**: 특약 내용이 제공된 법령의 **강행규정(임차인에게 불리한 약정은 효력이 없다는 규정 등)**에 명백히 위배되거나, 제공된 판례상 임차인의 권리를 부당하게 제한한다고 판단된 사례와 유사하면 `true`. 단순 절차 안내이거나 상호 합의 가능한 범위이면 `false`.
+    · **is_caution**: is_violation이 `false`이더라도, 제공된 법령·판례를 근거로 볼 때 임차인 또는 임대인 중 한쪽에게 실질적으로 불리하게 작용할 가능성이 있으면 `true`. 양쪽 모두에게 중립적이면 `false`.
+    · is_violation이 `true`이면 is_caution은 `false`로 설정하세요 (위배가 더 상위 개념).
 
   summary 작성 요령:
-    · 법률 전문 지식이 없는 일반인도 이해할 수 있도록 작성하세요.
-    · 이 법령/판례가 무슨 내용인지 쉬운 말로 설명하세요.
-    · **is_violation이 true인 경우**:
-        · 반드시 **어느 부분이 어떻게 법령에 위배되는지**, 그리고 **이 특약이 실제 법적 효력을 가질 수 있는지(무효 가능성 등)**를 매우 상세하고 구체적으로 서술하세요.
-        · 단순한 요약에 그치지 말고, 임차인이 이 조항을 보고 어떤 법적 권리를 주장할 수 있는지까지 상세히 안내하세요.
-    · **is_violation이 false인 경우**:
-        · 이 법령/판례가 특약에 미치는 영향이나 구체적인 연관성을 상식적인 수준에서 서술하세요.
-    · 이 특약 내용을 그대로 반복하지 마세요.
-    · 전문 용어는 괄호 안에 풀어쓰세요. 예) "대항력(집을 팔아도 계속 살 수 있는 권리)"
-  
-  summary 외에 다른 필드는 생성하지 마세요.
+    · **모든 summary에서 불릿 하나에 반드시 한 문장만** 작성하세요. 두 문장 이상이면 별도 불릿으로 분리하세요.
+    · **말투는 "~했음.", "~임.", "~가능함." 형식의 개조식**으로 작성하세요. "~합니다", "~세요", "~해요" 형식은 사용하지 마세요.
+    · **법률 전문 용어는 반드시 괄호 안에 풀어쓰세요.** 예) 묵시적 갱신(계약 만료 후 자동 연장), 중개보수(부동산 수수료), 강행규정(당사자가 바꿀 수 없는 법 조항)
+    · **법령(관련 법령 섹션 항목)**:
+        · is_violation 또는 is_caution이 `true`인 경우: 반드시 아래 **두 부분**으로 구성하세요. `#`, `##` 기호는 사용하지 마세요.
+          1. **첫 번째 줄**: 왜 문제가 되는지(위배) 일반인이 바로 이해할 수 있는 한 문장 요약
+          2. **빈 줄 하나** 삽입
+          3. **이후 내용**: 구체적인 이유, 근거 조항, 임차인/임대인이 주장할 수 있는 권리를 `- ` 불릿으로 서술 (불릿 하나 = 한 문장)
+        · is_violation과 is_caution 모두 `false`인 경우: 빈 문자열("")을 반환하세요.
+    · **판례(관련 판례 섹션 항목)**:
+        · is_violation이 `true`인 경우: 법령과 동일하게 아래 **두 부분**으로 구성하세요.
+          1. **첫 번째 줄**: 이 판례가 이 특약과 어떻게 충돌하는지 일반인이 바로 이해할 수 있는 한 문장 요약
+          2. **빈 줄 하나** 삽입
+          3. **이후 내용**: `- ` 불릿으로 아래 항목 서술 (불릿 하나 = 한 문장)
+             - **사건 개요**: 어떤 분쟁이었는지 한 문장으로 요약함.
+             - **법원 판단**: 법원이 어떻게 결론 내렸는지 한 문장으로 씀.
+             - **이 특약과의 관련성**: 왜 이 특약에서 주의해야 하는지 한 문장으로 씀.
+        · is_violation이 `false`인 경우: 빈 줄 없이 바로 `- ` 불릿으로 작성하세요. (불릿 하나 = 한 문장)
+          - **사건 개요**: 어떤 분쟁이었는지 한 문장으로 요약함.
+          - **법원 판단**: 법원이 어떻게 결론 내렸는지 한 문장으로 씀.
+          - **이 특약과의 관련성**: 왜 이 특약에서 주의해야 하는지 한 문장으로 씀.
+
 - JSON 외 텍스트, 마크다운 코드블록은 포함하지 마세요.
 
 {output_format}
@@ -236,6 +288,15 @@ def build_final_report_prompt(
 - 입력된 모든 특약을 종합 검토한 후, 확인 항목을 통합하여 작성하세요.
 - 계약서 전체 맥락에서 중요한 확인 사항을 도출하세요.
 - **주의**: 모든 인덱스는 1부터 시작합니다. **`특약0`은 존재하지 않으며 절대 사용하지 마세요.**
+- description: 법률 지식이 없는 일반인이 이해할 수 있도록 **쉬운 말**로 작성하세요.
+  · `- ` 불릿 포인트로 2~3개 항목으로 간결하게 정리하세요.
+  · `#`, `##` 등 제목 기호는 절대 사용하지 마세요.
+  · **불릿 하나에 반드시 한 문장만** 작성하세요. 두 문장 이상이면 별도 불릿으로 분리하세요.
+  · **말투는 "~했음.", "~임.", "~가능함." 형식의 개조식**으로 작성하세요. "~합니다", "~세요", "~해요" 형식은 사용하지 마세요.
+  · **법률 전문 용어는 반드시 괄호 안에 풀어쓰세요.** 예) 묵시적 갱신(계약 만료 후 자동 연장), 중개보수(부동산 수수료)
+  · 예시:
+    - 계약 전 임대인과 수선 범위를 명확히 합의하고 계약서에 기재해 두세요.
+    - 퇴거 시 분쟁 방지를 위해 입주 시 상태를 사진으로 기록해 두세요.
 - basis: 이 체크리스트 항목의 근거가 되는 특약 ID(예: "특약1", "공통특약 1")와 법령/판례 ref를 배열로 나열하세요. 반드시 본문에 등장한 식별자만 정확히 사용해야 합니다.
 
 2. clause_relations: 특약 간의 연관성 분석 (특약 vs 특약)
@@ -244,7 +305,7 @@ def build_final_report_prompt(
 - **주의**: 법령이나 판례와 특약의 관계는 이미 개별 요약에 포함되어 있으므로, 여기서는 절대 다루지 마세요. `clause_id`에 법령 식별자(예: 민법 제00조)를 넣는 것은 엄격히 금지됩니다.
 - `clause_id`들은 반드시 제공된 "특약1", "특약2", "공통특약 1" 형태의 식별자만 사용하세요.
 - **주의**: 각 특약의 원문 내용을 다른 특약 번호와 절대 혼동하지 마세요. 반드시 제공된 ID와 그에 해당하는 원문 내용을 정확히 매칭하여 분석하세요.
-- relation은 두 조항이 어떻게 연관되어 있으며 왜 주의해야 하는지 일반인 눈높이에서 설명하세요.
+- relation은 두 조항이 어떻게 연관되어 있으며 왜 주의해야 하는지 일반인 눈높이에서 **마크다운 형식**(`- ` 불릿)으로 설명하세요. `#`, `##` 기호는 사용하지 마세요. **불릿 하나에 반드시 한 문장만** 작성하고, **말투는 "~했음.", "~임." 개조식**으로, 법률 전문 용어는 괄호 안에 풀어쓰세요.
 - 연관성이 있는 특약에 대해서만 배열에 추가하세요.
 - clause_text는 null로 두세요.
 
@@ -264,7 +325,7 @@ def build_final_report_prompt(
 "contract_checklist": [
   {{
     "item": "원상복구 범위 및 귀책 기준 확인",
-    "description": "원상복구 의무의 범위는 임대 당시 목적물의 상태, 계약 체결 경위, 임차인이 수리하거나 변경한 내용 등을 개별적으로 고려하여 정해집니다. 계약 체결 전 또는 입주 시 임차 목적물의 현재 상태를 사진이나 영상으로 기록하고, 하자 부위를 계약서에 명기해 두면 퇴거 시 귀책 여부를 확인하는 근거로 활용할 수 있습니다.",
+    "description": "- 계약 전 임대인과 원상복구 범위를 구체적으로 합의하고 계약서에 기재해 두세요.\n- 입주 시 내부 상태를 사진·영상으로 기록해두면 퇴거 시 분쟁을 예방할 수 있어요.",
     "basis": ["특약A"]
   }}
 ],
@@ -332,14 +393,14 @@ from functools import lru_cache
 # ... (rest of the file)
 
 @lru_cache(maxsize=1024)
-def generate_clause_summary(target_clause: str, laws_json: str, precs_json: str) -> list[dict]:
+def generate_clause_summary(target_clause: str, laws_json: str, precs_json: str) -> dict:
     """1단계: 개별 특약의 법령/판례 요약만 생성 (독립적, 비동기 호출용)"""
     laws = json.loads(laws_json)
     precs = json.loads(precs_json)
-    
+
     prompt = build_clause_summary_prompt(target_clause, laws, precs)
-    result = call_llm(prompt, schema=ClauseSummaryOutput, model_override=MODEL_NAME_FLASH_LITE)
-    
+    result = call_llm(prompt, schema=ClauseSummaryOutput, model_override=MODEL_NAME_FLASH)
+
     rag_map: dict[str, dict] = {}
     for m in laws:
         did = m.get("doc_id", "")
@@ -349,19 +410,28 @@ def generate_clause_summary(target_clause: str, laws_json: str, precs_json: str)
         if did: rag_map[did] = {"type": LawType.case.value, "ref": did, "content": m.get("content") or m.get("summary") or ""}
 
     related_laws = []
+    clause_one_line_summary = ""
+    clause_interpretation = ""
     if result:
+        clause_one_line_summary = result.get("clause_one_line_summary") or ""
+        clause_interpretation = result.get("clause_interpretation") or ""
         covered = set()
         for sel in result.get("selected_laws", []):
             ref = (sel.get("ref") or "").strip()
             if ref in rag_map and ref not in covered:
                 related_laws.append({
-                    **rag_map[ref], 
-                    "summary": sel.get("summary"),
-                    "is_violation": sel.get("is_violation", False)
+                    **rag_map[ref],
+                    "summary": sel.get("summary") or "",
+                    "is_violation": sel.get("is_violation", False),
+                    "is_caution": sel.get("is_caution", False),
                 })
                 covered.add(ref)
 
-    return related_laws
+    return {
+        "clause_one_line_summary": clause_one_line_summary,
+        "clause_interpretation": clause_interpretation,
+        "related_laws": related_laws,
+    }
 
 
 def generate_final_report(property_info: dict, common_terms: list, clauses_with_hits_and_summaries: list[dict]) -> FinalReportOutput:
@@ -428,3 +498,94 @@ def generate_final_report(property_info: dict, common_terms: list, clauses_with_
         contract_checklist=final_checklist,
         related_clauses_map=relations_map
     )
+
+
+# ── 특약 재작성 ──────────────────────────────────────────
+
+class ClauseRewriteOutput(BaseModel):
+    rewritten_clause: str = ""
+    reason: str = ""
+
+    @field_validator("rewritten_clause", "reason", mode="before")
+    @classmethod
+    def coerce_str(cls, v):
+        if v is None:
+            return ""
+        if isinstance(v, list):
+            return "\n".join(str(x) for x in v if x)
+        return str(v)
+
+
+def generate_clause_rewrite(
+    original_clause: str,
+    violation_laws: list[dict],  # is_violation=True 항목: {ref, content, summary}
+    all_related_laws: list[dict],  # 전체 related_laws: {ref, content, summary, type}
+) -> dict:
+    """위반 가능성이 있는 특약을 법령에 맞게 재작성한다."""
+
+    violation_text = "\n\n".join(
+        f"[{item['ref']}]\n위반 요약: {item.get('summary', '')}\n원문: {item.get('content', '')}"
+        for item in violation_laws
+    ) or "해당 없음"
+
+    reference_text = "\n\n".join(
+        f"[{item['ref']}] ({item.get('type', '')})\n{item.get('content', '')}"
+        for item in all_related_laws
+        if not item.get("is_violation")
+    ) or "해당 없음"
+
+    output_format = json.dumps(
+        {
+            "rewritten_clause": "재작성된 특약 전문 (원문과 동일한 형식, 법령에 맞게 수정)",
+            "reason": "- **재작성 이유**:\n  - 원본 특약은 ... 때문에 문제가 됨.\n- **수정한 부분**:\n  - '원문 문구' → '수정 문구'로 변경함.\n- **법적 근거**:\n  - 주택임대차보호법 제○조에 따라 ... 임."
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    prompt = f"""
+[원본 특약]
+{original_clause}
+
+[위반 가능성이 있는 법령]
+{violation_text}
+
+[참고 법령·판례]
+{reference_text}
+
+[출력 지시]
+위 원본 특약이 위반 가능성이 있는 법령에 위배됩니다.
+법령을 준수하면서도 특약의 본래 의도를 최대한 살려 재작성하세요.
+
+- rewritten_clause: 재작성된 특약 전문을 작성하세요.
+  · 원본 특약과 동일한 문체(구어체/문어체)를 유지하세요.
+  · 법령 위반 소지가 있는 문구만 수정하고, 나머지는 원문을 최대한 유지하세요.
+  · 마크다운 기호는 사용하지 마세요. 특약 원문 형식 그대로 작성하세요.
+
+- reason: 재작성 이유를 아래 **중첩 불릿 구조**로 작성하세요.
+  · `#`, `##` 제목 기호는 사용하지 마세요.
+  · 최상위 불릿 3개: **재작성 이유**, **수정한 부분**, **법적 근거** (볼드 처리)
+  · 각 최상위 불릿 아래에 들여쓰기(`  - `)로 세부 내용을 작성하세요.
+  · **들여쓰기 불릿 하나에 반드시 한 문장만** 작성하세요. 두 문장 이상이면 별도 불릿으로 분리하세요.
+  · **말투는 "~했음.", "~임.", "~가능함." 형식의 개조식**으로 작성하세요.
+  · **독자는 법률 지식이 전혀 없는 일반인**임을 항상 염두에 두고, 중학생도 이해할 수 있는 쉬운 말로 작성하세요.
+  · **법률 전문 용어는 반드시 괄호 안에 일상 언어로 풀어쓰세요.** 예) 강행규정(법으로 정해져 있어서 당사자가 마음대로 바꿀 수 없는 조항), 계약갱신청구권(세입자가 "계약을 한 번 더 연장해 달라"고 요구할 수 있는 권리)
+  · 어려운 한자어나 법조문 표현은 쉬운 우리말로 바꾸세요. 예) "위배" → "어긋남", "배제" → "없앰", "준용" → "똑같이 적용"
+  · 형식 예시:
+    - **재작성 이유**:
+      - 원본 특약은 법으로 정해진 규정(당사자가 마음대로 바꿀 수 없는 조항)에 어긋남.
+      - 세입자가 "계약을 한 번 더 연장해 달라"고 요구할 수 있는 권리를 빼앗는 내용임.
+    - **수정한 부분**:
+      - '임차인은 계약 만료 시 갱신을 요구하지 않는다' → '임차인은 법이 허용하는 범위 안에서 갱신을 요청할 수 있다'로 바꿈.
+    - **법적 근거**:
+      - 주택임대차보호법 제6조의3에 따르면, 세입자의 계약 연장 요구 권리는 특약으로 없앨 수 없음.
+
+- JSON 외 텍스트, 마크다운 코드블록은 포함하지 마세요.
+
+{output_format}
+"""
+
+    result = call_llm(prompt, schema=ClauseRewriteOutput, model_override=MODEL_NAME_FLASH)
+    if not result:
+        return {"rewritten_clause": "", "reason": ""}
+    return result


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 요약해주세요. -->
위반 가능성 특약 재작성 기능을 중심으로, 분석 결과 고도화·문서 삭제·챗봇 개선이 함께 포함됩니다.
(백엔드 `main.py`/`report_generator_v2.py`와 프론트 `analysis/page.tsx`에 여러 기능이 한 번에 반영되어 있습니다.)

- **특약 재작성(rewrite)**: `POST /api/analyze/rewrite_clause` 추가, `generate_clause_rewrite` LLM 함수, 재작성 요청/응답 스키마, 프론트 재작성 제안 모달·세션 캐시 UI.
- **특약 분석 고도화**: 한 줄 요약(`clause_one_line_summary`)·일반인 해석(`clause_interpretation`)·주의(`is_caution`) 등급 생성 및 표시, 프롬프트 개조식 톤 통일.
- **문서 삭제**: `DELETE /api/documents/{doc_id}` 추가(DB·GCS 동시 삭제).
- **챗봇 개선**: `search_legal_info` 준비 상태 가드/예외 처리, 환각 방지 지침·특약 번호 해석 규칙 강화, 도구 자동 호출 잠정 중단, 서비스명 ADE→CLARA.
- **분석 화면 UI**: 분석/체크리스트 탭, 근거 팝오버, 토스트, 특약 클릭 하이라이트(`activeClauseIdx`).

## 🔗 관련 이슈
<!-- 관련 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
closes #130

## 📸 스크린샷 (선택)
<!-- UI 변경이 있는 경우 Before/After 스크린샷을 첨부해주세요. -->
| Before | After |
|--------|-------|
|        |       |

## 🧪 테스트
<!-- 어떻게 테스트했는지 설명해주세요. -->
- [ ] `POST /api/analyze/rewrite_clause` 호출 → 재작성 특약·근거 정상 반환 확인
- [ ] `DELETE /api/documents/{doc_id}` 호출 → DB·GCS 파일 삭제 및 404/500 분기 확인
- [ ] 분석 화면에서 한 줄 요약·해석·주의 배지 렌더링 확인
- [ ] 특약 재작성 모달 로딩/완료/에러 상태 및 세션 캐시 동작 확인
- [ ] 챗봇이 분석 문서에 없는 질문에 추측 없이 거절하는지 확인

## ✅ 체크리스트
<!-- 아래 항목을 모두 확인한 후 리뷰를 요청해주세요. -->
- [ ] 코드가 정상적으로 동작합니다.
- [ ] 커밋 메시지가 컨벤션을 따릅니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
<!-- 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요. -->
- ⚠️ **빌드 의존성**: 이 브랜치의 `analysis/page.tsx`는 아직 이 브랜치에 포함되지 않은 컴포넌트 prop을 사용합니다.
  - `DocumentPanel`의 `activeIdx` prop (line 530)
  - `ChatBot`의 `showNudge` / `rewrittenClauses` prop (line 1115, 1122)
  - 즉 `DocumentPanel.tsx`·`ChatBot.tsx` 변경(별도 진행분)이 **함께 머지되어야 타입 체크/빌드가 통과**합니다. 단독 머지 시 프론트 빌드가 깨질 수 있어, 후속 PR과의 머지 순서를 확인해주세요.
- 커밋 이름은 '재작성' 위주지만 실제로는 여러 기능이 같은 파일에 섞여 있습니다. 리뷰 시 파일별 diff 범위를 참고해주세요.
- LLM 프롬프트 변경(개조식 톤·주의 등급 기준)이 의도대로 출력되는지 함께 봐주시면 좋겠습니다.