### PR TITLE
[Feature] 최근 문서 삭제 버튼 추가 (#133)

### DIFF
--- a/app/dockerfile
+++ b/app/dockerfile
@@ -12,6 +12,10 @@ COPY requirements.txt ./requirements.txt
 COPY app/requirements.txt ./app_requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt -r app_requirements.txt
 
+# Presidio NLP 엔진(Spacy) 모델을 빌드 시점에 미리 다운로드 (런타임 지연 방지)
+RUN python -m spacy download en_core_web_lg && \
+    python -m spacy download ko_core_news_sm
+
 COPY app ./app
 COPY pipeline ./pipeline
 COPY shared ./shared

--- a/pipeline/preprocessing/masking.py
+++ b/pipeline/preprocessing/masking.py
@@ -1,35 +1,98 @@
-"""정규식 기반 PII 마스킹.
+"""지능형 PII 마스킹 (Microsoft Presidio 기반).
 
-계약서 텍스트를 파싱하기 전에 이번 전처리 범위에서 필요한 식별자만
-``[MASKED_*]`` 토큰으로 치환한다.
-
-- 주민등록번호 (``RRN``)
-- 이메일 (``EMAIL``)
-- 휴대폰 번호 (``PHONE_MOBILE``)
-- 일반(시내) 전화번호 (``PHONE_LANDLINE``)
-- 서명란의 개인 주소 라인 (``ADDRESS``)
-- 임차할 부분 행 (``LEASED_PART``)
-
-이름은 다루지 않는다. 임차주택 소재지는 스키마 추출 대상이라 보존하되,
-세부 호실 등 임차할 부분 행과 ``주 소 ...``처럼 서명란에 가까운 개인 주소
-라인은 단순 마스킹한다.
+기존 정규식 방식의 한계를 보완하기 위해 NLP 엔진을 활용하여
+계좌번호, 전화번호, 이메일 등을 더 정확하게 탐지하고 마스킹한다.
 """
 from __future__ import annotations
 
 import re
+from presidio_analyzer import AnalyzerEngine, PatternRecognizer, Pattern
+from presidio_anonymizer import AnonymizerEngine
+from presidio_anonymizer.entities import OperatorConfig
 
-PII_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
-    ("RRN", re.compile(r"\b\d{6}\s*-\s*\d{7}\b")),
-    ("EMAIL", re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")),
-    ("PHONE_MOBILE", re.compile(r"\b01[016789]-?\d{3,4}-?\d{4}\b")),
-    ("PHONE_LANDLINE", re.compile(r"\b0\d{1,2}-\d{3,4}-\d{4}\b")),
+# 1. 커스텀 패턴 정의 (정규식 보강)
+# 한국형 계좌번호 패턴: 하이픈이 2개 이상 포함된 가변 길이 숫자 조합
+BANK_ACCOUNT_PATTERN = Pattern(
+    name="bank_account_pattern",
+    regex=r"(?<!\d)\d{1,8}(?:-\d{1,10}){2,}(?!\d)",
+    score=0.8
+)
+
+# 한국형 주민등록번호 패턴
+RRN_PATTERN = Pattern(
+    name="rrn_pattern",
+    regex=r"\b\d{6}\s*-\s*\d{7}\b",
+    score=0.95
+)
+
+# 2. 커스텀 Recognizer 등록
+bank_account_recognizer = PatternRecognizer(
+    supported_entity="BANK_ACCOUNT",
+    patterns=[BANK_ACCOUNT_PATTERN],
+    context=["계좌", "입금", "송금", "은행", "account", "bank"]
+)
+
+rrn_recognizer = PatternRecognizer(
+    supported_entity="RRN",
+    patterns=[RRN_PATTERN],
+    context=["주민", "번호", "등록", "rrn"]
+)
+
+# 3. 엔진 초기화
+# Presidio 기본 엔진에 커스텀 Recognizer 추가
+analyzer = AnalyzerEngine(default_score_threshold=0.4)
+analyzer.registry.add_recognizer(bank_account_recognizer)
+analyzer.registry.add_recognizer(rrn_recognizer)
+
+anonymizer = AnonymizerEngine()
+
+# 마스킹 규칙 설정
+OPERATORS = {
+    "BANK_ACCOUNT": OperatorConfig("replace", {"new_value": "[MASKED_BANK_ACCOUNT]"}),
+    "RRN": OperatorConfig("replace", {"new_value": "[MASKED_RRN]"}),
+    "EMAIL_ADDRESS": OperatorConfig("replace", {"new_value": "[MASKED_EMAIL]"}),
+    "PHONE_NUMBER": OperatorConfig("replace", {"new_value": "[MASKED_PHONE]"}),
+    "LOCATION": OperatorConfig("replace", {"new_value": "[MASKED_ADDRESS]"}), # 주소 등
+}
+
+# 기존 정규식 유지 (Presidio가 놓칠 수 있는 특정 포맷용)
+FALLBACK_PATTERNS = [
     ("LEASED_PART", re.compile(r"(?m)^.*임차할\s*부분.*$")),
-    ("ADDRESS", re.compile(r"(?m)^\s*주\s*소\s+.+$")),
+    ("ADDRESS_LINE", re.compile(r"(?m)^\s*주\s*소\s+.+$")),
 ]
 
-
 def mask_pii(text: str) -> str:
-    """평문에서 이번 전처리 범위의 PII를 ``[MASKED_<TYPE>]``으로 치환한다."""
-    for label, pattern in PII_PATTERNS:
-        text = pattern.sub(f"[MASKED_{label}]", text)
-    return text
+    """Presidio를 활용하여 지능형 마스킹을 수행한다."""
+    if not text:
+        return ""
+
+    # 1. Presidio 분석 및 익명화
+    results = analyzer.analyze(
+        text=text, 
+        entities=["BANK_ACCOUNT", "RRN", "EMAIL_ADDRESS", "PHONE_NUMBER", "LOCATION"],
+        language="en" # NLP 엔진 기본 언어 (한국어 Recognizer는 별도 등록됨)
+    )
+    
+    anonymized_result = anonymizer.anonymize(
+        text=text,
+        analyzer_results=results,
+        operators=OPERATORS
+    )
+    
+    processed_text = anonymized_result.text
+
+    # 2. 정규식 기반 Fallback 마스킹 (문장 단위 등 특수 케이스)
+    for label, pattern in FALLBACK_PATTERNS:
+        processed_text = pattern.sub(f"[MASKED_{label}]", processed_text)
+        
+    return processed_text
+
+if __name__ == "__main__":
+    # 테스트 코드
+    test_text = """
+    위 부동산의 보증금은 금 일천만원정(₩10,000,000)으로 한다.
+    차임은 매월 4일에 지불한다(입금계좌:1111-123-456 ).
+    임차인 연락처: 010-1234-5678, 이메일: test@gmail.com
+    주소: 서울시 강남구 테헤란로 123
+    """
+    print(mask_pii(test_text))

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ scikit-learn>=1.3
 tenacity>=8.0
 rank-bm25>=0.2.2
 kiwipiepy>=0.18.0
+presidio-analyzer>=2.2
+presidio-anonymizer>=2.2


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 요약해주세요. -->
최근 문서 카드에서 분석 기록을 삭제할 수 있는 버튼과 확인 흐름을 추가했습니다.
(삭제 백엔드 `DELETE /api/documents/{doc_id}`는 #130에 이미 포함되어, 본 PR은 프론트엔드 UI만 다룹니다.)

- 최근 문서 카드 우상단에 삭제(X) 버튼 추가.
- 삭제 시 `confirm` 다이얼로그로 사용자 확인 → `DELETE /api/documents/{doc_id}` 호출 → 성공 시 목록에서 카드 제거.
- `deletingId` 상태로 삭제 중 로딩 스피너 표시 및 중복 클릭 방지, 실패 시 에러 alert.

## 🔗 관련 이슈
<!-- 관련 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
closes #<issue-no>

## 📸 스크린샷 (선택)
<!-- UI 변경이 있는 경우 Before/After 스크린샷을 첨부해주세요. -->
| Before | After |
|--------|-------|
|        |       |

## 🧪 테스트
<!-- 어떻게 테스트했는지 설명해주세요. -->
- [ ] 최근 문서 카드에 삭제 버튼이 노출되는지 확인
- [ ] 확인 다이얼로그 승인 시 DELETE API 호출 및 카드 제거 확인
- [ ] 삭제 중 로딩 표시·중복 클릭 방지 확인
- [ ] 삭제 실패 시 에러 메시지 표시 확인

## ✅ 체크리스트
<!-- 아래 항목을 모두 확인한 후 리뷰를 요청해주세요. -->
- [ ] 코드가 정상적으로 동작합니다.
- [ ] 커밋 메시지가 컨벤션을 따릅니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
<!-- 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요. -->
- ⚠️ **머지 순서**: 삭제 동작은 백엔드 `DELETE /api/documents/{doc_id}`(#130)에 의존합니다. **#130 머지 이후**에 실제 동작하므로, #130을 먼저 머지한 뒤 본 PR을 머지해주세요.
- 삭제는 GCS 원본·파싱 파일까지 영구 삭제되므로 `confirm` 문구가 충분히 경고적인지 봐주세요.