### PR TITLE
[Feature] 홈/업로드 화면 UI 개선 (#135)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -30,6 +30,10 @@
   --color-border-upload: #C4C6CF;
 }
 
+html {
+  font-size: 18px;
+}
+
 body {
   background: var(--color-page-bg);
   font-family: var(--font-public-sans), sans-serif;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -91,7 +91,7 @@ export default function UploadPage() {
                 className="mt-2 text-sm"
                 style={{ color: "#43474E", fontFamily: "var(--font-public-sans)" }}
               >
-                PDF를 업로드하면 조항 추출과 위험 검토를 시작합니다.
+                PDF를 업로드하면 계약서 검토를 시작합니다.
               </p>
             </div>
           ) : (

--- a/frontend/components/UploadDropzone.tsx
+++ b/frontend/components/UploadDropzone.tsx
@@ -6,7 +6,7 @@ import { FileUp, Loader2 } from "lucide-react";
 
 const MAX_BYTES = 20 * 1024 * 1024;
 const ACCEPT =
-  ".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+  ".pdf,application/pdf";
 
 type UploadDropzoneProps = {
   onFileSelect: (file: File) => void;
@@ -23,12 +23,9 @@ function formatSize(bytes: number): string {
 
 function isAllowedFile(file: File): boolean {
   const lower = file.name.toLowerCase();
-  if (lower.endsWith(".pdf") || lower.endsWith(".docx")) return true;
+  if (lower.endsWith(".pdf")) return true;
   const t = file.type;
-  return (
-    t === "application/pdf" ||
-    t === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-  );
+  return t === "application/pdf";
 }
 
 export function UploadDropzone({ onFileSelect, isLoading }: UploadDropzoneProps) {
@@ -41,7 +38,7 @@ export function UploadDropzone({ onFileSelect, isLoading }: UploadDropzoneProps)
     if (!file) return;
     setError(null);
     if (!isAllowedFile(file)) {
-      setError("PDF 또는 DOCX 파일만 업로드할 수 있습니다.");
+      setError("PDF 파일만 업로드할 수 있습니다.");
       setPreview(null);
       return;
     }
@@ -122,7 +119,7 @@ export function UploadDropzone({ onFileSelect, isLoading }: UploadDropzoneProps)
         className="mt-2 text-xs"
         style={{ color: "#74777F", fontFamily: "var(--font-public-sans)" }}
       >
-        지원 형식: PDF, DOCX · 최대 용량: 20MB
+        지원 형식: PDF · 최대 용량: 20MB
       </p>
 
       {error && (


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 요약해주세요. -->
홈/업로드 화면의 업로드 형식 제한과 기본 폰트·안내 문구를 개선했습니다.
(분석 화면 UI 개선은 #130에 이미 포함되어, 본 PR은 홈/업로드 파트만 다룹니다.)

- 업로드 허용 형식을 **PDF 전용**으로 제한 (`accept`·`isAllowedFile` 검증·에러 메시지·안내 문구에서 DOCX 제거).
- 홈 화면 안내 카피를 "PDF를 업로드하면 계약서 검토를 시작합니다."로 정리.
- 전역 기본 폰트 크기를 18px로 상향하여 가독성 개선.

## 🔗 관련 이슈
<!-- 관련 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
closes #135 

## 📸 스크린샷 (선택)
<!-- UI 변경이 있는 경우 Before/After 스크린샷을 첨부해주세요. -->
| Before | After |
|--------|-------|
|        |       |

## 🧪 테스트
<!-- 어떻게 테스트했는지 설명해주세요. -->
- [ ] PDF 외 파일(DOCX 등) 업로드 시 "PDF 파일만 업로드할 수 있습니다." 에러 표시 확인
- [ ] 업로드 안내 문구가 "지원 형식: PDF · 최대 용량: 20MB"로 표기되는지 확인
- [ ] 홈 화면 안내 카피 변경 확인
- [ ] 기본 폰트 크기 상향(18px)이 화면 전반에 반영되는지 확인

## ✅ 체크리스트
<!-- 아래 항목을 모두 확인한 후 리뷰를 요청해주세요. -->
- [ ] 코드가 정상적으로 동작합니다.
- [ ] 커밋 메시지가 컨벤션을 따릅니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
<!-- 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 폰트 크기 18px 상향이 기존 레이아웃(여백·줄바꿈)에 깨지는 부분이 없는지 함께 봐주세요.
- 독립 변경이라 머지 순서 제약은 없습니다.