### PR TITLE
[Feature] 최근 문서 삭제 버튼 추가 (#137)

### DIFF
--- a/frontend/components/RecentDocumentPanel.tsx
+++ b/frontend/components/RecentDocumentPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { ChevronRight, FileText, Loader2 } from "lucide-react";
+import { ChevronRight, FileText, Loader2, X } from "lucide-react";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
 
@@ -14,11 +14,15 @@ type DocumentHistoryItem = {
 function RecentDocumentCard({ 
   doc, 
   onSelect,
-  isSelecting 
+  onDelete,
+  isSelecting,
+  isDeleting
 }: { 
   doc: DocumentHistoryItem; 
   onSelect: (doc: DocumentHistoryItem) => void;
+  onDelete: (doc: DocumentHistoryItem) => void;
   isSelecting: boolean;
+  isDeleting: boolean;
 }) {
   const dateStr = new Date(doc.created_at).toLocaleDateString("ko-KR", {
     year: "numeric",
@@ -28,7 +32,7 @@ function RecentDocumentCard({
 
   return (
     <article
-      className="rounded-lg border p-4 shadow-sm transition"
+      className="relative rounded-lg border p-4 shadow-sm transition"
       style={{
         background: "white",
         borderColor: "#E2E8F0",
@@ -40,11 +44,24 @@ function RecentDocumentCard({
         (e.currentTarget as HTMLElement).style.borderColor = "#E2E8F0";
       }}
     >
+      {/* 삭제 버튼 */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete(doc);
+        }}
+        disabled={isDeleting || isSelecting}
+        className="absolute top-3 right-3 p-1 text-gray-300 hover:text-red-500 transition-colors rounded-md hover:bg-red-50 disabled:opacity-30"
+        title="삭제"
+      >
+        {isDeleting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <X className="h-3.5 w-3.5" />}
+      </button>
+
       <div className="flex items-start gap-3">
         <div className="mt-0.5 rounded bg-blue-50 p-2 text-blue-600">
           <FileText className="h-4 w-4" />
         </div>
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 pr-6">
           <h4
             className="truncate text-sm font-medium leading-snug"
             style={{ color: "#1A1C1E", fontFamily: "var(--font-public-sans)" }}
@@ -65,7 +82,7 @@ function RecentDocumentCard({
         <button
           type="button"
           onClick={() => onSelect(doc)}
-          disabled={isSelecting}
+          disabled={isSelecting || isDeleting}
           className="inline-flex items-center gap-1 text-xs font-medium hover:underline disabled:opacity-50"
           style={{ color: "#002045", fontFamily: "var(--font-public-sans)" }}
         >
@@ -81,6 +98,7 @@ export function RecentDocumentPanel() {
   const [docs, setDocs] = useState<DocumentHistoryItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [selectingId, setSelectingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   useEffect(() => {
     async function fetchHistory() {
@@ -133,6 +151,32 @@ export function RecentDocumentPanel() {
     }
   }
 
+  async function handleDelete(doc: DocumentHistoryItem) {
+    const clientId = localStorage.getItem("ade.client_id");
+    if (!clientId) return;
+
+    if (!confirm(`'${doc.file_name}' 분석 기록을 삭제하시겠습니까?\n이 작업은 되돌릴 수 없으며 실제 파일도 함께 삭제됩니다.`)) {
+      return;
+    }
+
+    setDeletingId(doc.doc_id);
+    try {
+      const res = await fetch(`${API_BASE}/api/documents/${doc.doc_id}?client_id=${clientId}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        setDocs(prev => prev.filter(d => d.doc_id !== doc.doc_id));
+      } else {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.detail || "삭제 실패");
+      }
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "삭제 중 오류가 발생했습니다.");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
   return (
     <aside
       className="flex h-full min-h-0 w-full flex-col gap-4 overflow-y-auto lg:w-[320px] lg:shrink-0 lg:border-l lg:pl-6"
@@ -156,7 +200,9 @@ export function RecentDocumentPanel() {
               <RecentDocumentCard 
                 doc={doc} 
                 onSelect={handleSelect} 
+                onDelete={handleDelete}
                 isSelecting={selectingId === doc.doc_id}
+                isDeleting={deletingId === doc.doc_id}
               />
             </li>
           ))}


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 요약해주세요. -->
최근 문서 카드에서 분석 기록을 삭제할 수 있는 버튼과 확인 흐름을 추가했습니다.
(삭제 백엔드 `DELETE /api/documents/{doc_id}`는 #130에 이미 포함되어, 본 PR은 프론트엔드 UI만 다룹니다.)

- 최근 문서 카드 우상단에 삭제(X) 버튼 추가.
- 삭제 시 `confirm` 다이얼로그로 사용자 확인 → `DELETE /api/documents/{doc_id}` 호출 → 성공 시 목록에서 카드 제거.
- `deletingId` 상태로 삭제 중 로딩 스피너 표시 및 중복 클릭 방지, 실패 시 에러 alert.

## 🔗 관련 이슈
<!-- 관련 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
closes #<issue-no>

## 📸 스크린샷 (선택)
<!-- UI 변경이 있는 경우 Before/After 스크린샷을 첨부해주세요. -->
| Before | After |
|--------|-------|
|        |       |

## 🧪 테스트
<!-- 어떻게 테스트했는지 설명해주세요. -->
- [ ] 최근 문서 카드에 삭제 버튼이 노출되는지 확인
- [ ] 확인 다이얼로그 승인 시 DELETE API 호출 및 카드 제거 확인
- [ ] 삭제 중 로딩 표시·중복 클릭 방지 확인
- [ ] 삭제 실패 시 에러 메시지 표시 확인

## ✅ 체크리스트
<!-- 아래 항목을 모두 확인한 후 리뷰를 요청해주세요. -->
- [ ] 코드가 정상적으로 동작합니다.
- [ ] 커밋 메시지가 컨벤션을 따릅니다.
- [ ] 셀프 리뷰를 완료했습니다.
- [ ] 테스트를 추가/수정했습니다 (해당되는 경우).
- [ ] 문서를 업데이트했습니다 (해당되는 경우).

## 💬 리뷰어에게
<!-- 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요. -->
- ⚠️ **머지 순서**: 삭제 동작은 백엔드 `DELETE /api/documents/{doc_id}`(#130)에 의존합니다. **#130 머지 이후**에 실제 동작하므로, #130을 먼저 머지한 뒤 본 PR을 머지해주세요.
- 삭제는 GCS 원본·파싱 파일까지 영구 삭제되므로 `confirm` 문구가 충분히 경고적인지 봐주세요.
